### PR TITLE
Increase CCPi-DVC version requirement

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # ChangeLog
 
+## v21.1.1
+* Increases ccpi-dvc version requirement to 21.1.0.
+* This fixes issue of missing DLLs when running DVC exe on windows
+
 ## v21.1.0
 * the package renamed to idvc
 * version string from git describe

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,7 +44,7 @@ requirements:
     - python
     - numpy
     - ccpi-viewer >=21.0.1
-    - ccpi-dvc >=21.0.0
+    - ccpi-dvc >=21.1.0
     - natsort
     - docopt
     - matplotlib


### PR DESCRIPTION
This is necessary to fix the issue of DLL errors when running the DVC executable on windows, in the case that you don't have Visual Studio installed.