### PR TITLE
Show all error messages produced by DVC code

### DIFF
--- a/src/idvc/dvc_interface.py
+++ b/src/idvc/dvc_interface.py
@@ -5820,7 +5820,7 @@ def generateUIDockParameters(self, title): #copied from dvc_configurator.py
 
 def main():
     err = vtk.vtkFileOutputWindow()
-    err.SetFileName("viewer.log")
+    err.SetFileName("../viewer.log")
     vtk.vtkOutputWindow.SetInstance(err)
 
     # log = open("dvc_interface.log", "a")


### PR DESCRIPTION
Closes #61 and #58 

There are 2 ways an error may occur with a QProcess:

1. Something goes wrong with the QProcess itself. e.g. it fails to start because the command is wrong. We find out about this kind of error through the signal `errorOccurred`: https://github.com/TomographicImaging/iDVC/blob/9db3ae97ac7d63562f0afadbc4047607fa190ffd/src/idvc/dvc_runner.py#L310
2. Something is wrong in the executable we are running with the QProcess. E.g. an exception is raised. In this case we don't get an  `errorOccurred` signal, we get a `readyReadStandardError` signal: https://github.com/TomographicImaging/iDVC/blob/9db3ae97ac7d63562f0afadbc4047607fa190ffd/src/idvc/dvc_runner.py#L325

I tested the creation of error messages in the above 2 cases by making a dummy executable.

In the DVC executable the errors that arise seem to result in print statements - these make a 'readyReadStandardOutput' signal happen https://github.com/TomographicImaging/iDVC/blob/9db3ae97ac7d63562f0afadbc4047607fa190ffd/src/idvc/dvc_runner.py#L322 and they are dealt with here https://github.com/TomographicImaging/iDVC/blob/9db3ae97ac7d63562f0afadbc4047607fa190ffd/src/idvc/dvc_runner.py#L87 if they are an 'Input Error' - I have not looked into whether there are other errors that could occur as print statements - I need to dig into the dvc.exe code.

Leaving this as draft for the above reason and also I found the app ocassionally crashes after an error dialog has been made, and I haven't figured out when/why this happens yet.