### PR TITLE
move viewer log file outside of current session folder

### DIFF
--- a/src/idvc/dvc_interface.py
+++ b/src/idvc/dvc_interface.py
@@ -5820,7 +5820,7 @@ def generateUIDockParameters(self, title): #copied from dvc_configurator.py
 
 def main():
     err = vtk.vtkFileOutputWindow()
-    err.SetFileName("viewer.log")
+    err.SetFileName("../viewer.log")
     vtk.vtkOutputWindow.SetInstance(err)
 
     # log = open("dvc_interface.log", "a")


### PR DESCRIPTION
closes #58 

viewer.log file is saved in the DVC_Sessions folder rather than in the folder of the current session