### PR TITLE
Fixes error in displaying DVC results

### DIFF
--- a/src/idvc/dvc_interface.py
+++ b/src/idvc/dvc_interface.py
@@ -76,11 +76,11 @@ from qdarkstyle.dark.palette import DarkPalette
 from qdarkstyle.light.palette import LightPalette
 
 from idvc import version as gui_version
-from idvc.dialogs import SettingsWindow
+from dialogs import SettingsWindow
 
 from brem.ui import RemoteFileDialog
 from brem import AsyncCopyOverSSH
-from idvc.dvc_remote import DVCRemoteRunControl
+from dvc_remote import DVCRemoteRunControl
 
 __version__ = gui_version.version
 
@@ -3992,7 +3992,7 @@ This parameter has a strong effect on computation time, so be careful."
                                message="Load a mask on the viewer first" )
                 return
         
-        folder_name = "_" + self.rdvc_widgets['name_entry'].text()
+        folder_name = self.rdvc_widgets['name_entry'].text()
 
         results_folder = os.path.join(tempfile.tempdir, "Results")
 
@@ -4094,7 +4094,7 @@ This parameter has a strong effect on computation time, so be careful."
         os.chdir(tempfile.tempdir)
         progress_callback = kwargs.get('progress_callback', None)
         try:
-            folder_name = "_" + self.rdvc_widgets['name_entry'].text()
+            folder_name = self.rdvc_widgets['name_entry'].text()
 
             results_folder = os.path.join(tempfile.tempdir, "Results")
             os.mkdir(os.path.join(results_folder, folder_name))

--- a/src/idvc/dvc_interface.py
+++ b/src/idvc/dvc_interface.py
@@ -76,11 +76,11 @@ from qdarkstyle.dark.palette import DarkPalette
 from qdarkstyle.light.palette import LightPalette
 
 from idvc import version as gui_version
-from dialogs import SettingsWindow
+from idvc.dialogs import SettingsWindow
 
 from brem.ui import RemoteFileDialog
 from brem import AsyncCopyOverSSH
-from dvc_remote import DVCRemoteRunControl
+from idvc.dvc_remote import DVCRemoteRunControl
 
 __version__ = gui_version.version
 


### PR DESCRIPTION
Some other things to note:

For running on vishighmem01 I had to change the command from:
https://github.com/TomographicImaging/iDVC/blob/566fef6f229f128b7d3a736ad3e70a15a19b4f20/src/idvc/dvc_remote.py#L102

to: `'cd {} &&  conda activate dvc && dvc dvc_config.txt'`
i.e. I had to delete the` .~/condarc `part to get it to work 

Also when I tried to run locally on this branch I got an error (which I haven't investigated):

```
Traceback (most recent call last):
  File "c:/Users/lhe97136/Work/iDVC/src/idvc/dvc_interface.py", line 4010, in create_config_worker
    if not self.settings_window.fw.widgets['connect_to_remote_field'].isChecked():
AttributeError: 'MainWindow' object has no attribute 'settings_window'
```