### PR TITLE
Update names of readers in io file to match viewer changes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,12 @@
 # ChangeLog
 
-## v21.#.#
+## v22.0.0
+* Requires v22.0.0 of the CILViewer due to backwards incompatibility of reader restructuring, and requirement of vtk 8.1.2 in iDVC.
+* Fixes bug with incorrect bit depth being passed to dvc code if a int16 raw file is used.
 * Moved io.py from CILViewer to this package
 * Generate version.py from setup.py
 * Changed the directory structure for the configuration files for a single or bulk which are now saved at as same level subdirectories as Result/<run_name>/dvc_result_<run_number>. The Bulk run will launch a DVC execution consequently for each directory.
+
 
 ## v21.1.2
 * Only use relative filepaths to session files

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,7 @@ requirements:
   run:
     - python
     - numpy
-    - ccpi-viewer >=21.1.2
+    - ccpi-viewer ==22.0.0
     - ccpi-dvc >=21.1.0
     - natsort
     - docopt

--- a/src/idvc/io.py
+++ b/src/idvc/io.py
@@ -8,8 +8,8 @@ from functools import partial
 import numpy
 import vtk
 from ccpi.viewer.utils import Converter
-from ccpi.viewer.utils.conversion import (cilBaseCroppedReader,
-                                          cilBaseResampleReader,
+from ccpi.viewer.utils.conversion import (cilRawCroppedReader,
+                                          cilRawResampleReader,
                                           cilMetaImageCroppedReader,
                                           cilMetaImageResampleReader,
                                           cilNumpyCroppedReader,
@@ -789,18 +789,14 @@ def saveRawImageData(**kwargs):
         return (errors)
 
     if resample:
-        reader = cilBaseResampleReader()
+        reader = cilRawResampleReader()
         reader.AddObserver(vtk.vtkCommand.ProgressEvent, partial(
             getProgress, progress_callback=progress_callback))
         reader.SetFileName(fname)
         reader.SetTargetSize(int(target_size * 1024*1024*1024))
-        reader.SetBytesPerElement(bytes_per_element)
         reader.SetBigEndian(isBigEndian)
         reader.SetIsFortran(isFortran)
-        # typecode = numpy.dtype(main_window.raw_import_dialog['dtype'].currentText()).char
-        # reader.SetNumpyTypeCode(typecode)
-        # reader.SetOutputVTKType(Converter.numpy_dtype_char_to_vtkType[typecode])
-        reader.SetRawTypeCode(
+        reader.SetTypeCodeName(
             main_window.raw_import_dialog['dtype'].currentText())
         reader.SetStoredArrayShape(shape)
         # We have not set spacing or origin
@@ -820,19 +816,15 @@ def saveRawImageData(**kwargs):
             else:
                 info_var['sampled'] = True
     elif crop_image:
-        reader = cilBaseCroppedReader()
+        reader = cilRawCroppedReader()
         reader.AddObserver(vtk.vtkCommand.ProgressEvent, partial(
             getProgress, progress_callback=progress_callback))
         reader.SetFileName(fname)
         reader.SetTargetZExtent(target_z_extent)
         reader.SetOrigin(tuple(origin))
-        reader.SetBytesPerElement(bytes_per_element)
         reader.SetBigEndian(isBigEndian)
         reader.SetIsFortran(isFortran)
-        # typecode = numpy.dtype(main_window.raw_import_dialog['dtype'].currentText()).char
-        # reader.SetNumpyTypeCode(typecode)
-        # reader.SetOutputVTKType(Converter.numpy_dtype_char_to_vtkType[typecode])
-        reader.SetRawTypeCode(
+        reader.SetTypeCodeName(
             main_window.raw_import_dialog['dtype'].currentText())
         reader.SetStoredArrayShape(shape)
         # We have not set spacing or origin
@@ -843,9 +835,7 @@ def saveRawImageData(**kwargs):
         #print ("Spacing ", output_image.GetSpacing())
         image_size = reader.GetStoredArrayShape(
         )[0] * reader.GetStoredArrayShape()[1]*reader.GetStoredArrayShape()[2]
-        # target_size = reader.GetTargetSize()
         # print("array shape", image_size)
-        # print("target", target_size)
         if info_var is not None:
             info_var['cropped'] = True
 


### PR DESCRIPTION
Updates to use changes in:  https://github.com/vais-ral/CILViewer/pull/192

Requires CILViewer v22.0.0 due to vtk 8.1.2 requirement of iDVC (due to #77 ) and backwards incompatibility with previous versions of the viewer.

Once we have merged this I propose we release version 22.0.0 of iDVC - see the change log