### PR TITLE
Update conda-package-publish version to v1.4.3

### DIFF
--- a/.github/workflows/conda_build_and_publish.yml
+++ b/.github/workflows/conda_build_and_publish.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: publish-to-conda
-      uses: paskino/conda-package-publish-action@v1.4.1
+      uses: paskino/conda-package-publish-action@v1.4.3
       with:
         subDir: 'recipe'
         channels: 'conda-forge -c ccpi -c paskino'


### PR DESCRIPTION
This is necessary so that we can publish a noarch package