### PR TITLE
Restrict VTK version  and CILViewer version due to backwards incompatability

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # ChangeLog
 
-## v22.x.x
+## v22.1.0
 * Correctly scales total displacement vectors 
 * Correctly align help text
 * Make dockwidgets uncloseable, so that 3D viewer can't be lost.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,13 +41,14 @@ requirements:
   run:
     - python
     - numpy
-    - ccpi-viewer >=22.0.1, <22.1.0
+    - ccpi-viewer
     - ccpi-dvc >=21.1.0
     - natsort
     - docopt
     - matplotlib
     - openmp                # [osx]
     - qdarkstyle
+    - vtk=8.1.2
 
 about:
   home: http://www.ccpi.ac.uk

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,7 @@ requirements:
   run:
     - python
     - numpy
-    - ccpi-viewer
+    - ccpi-viewer >= 22.2.0
     - ccpi-dvc >=21.1.0
     - natsort
     - docopt

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,7 @@ requirements:
   run:
     - python
     - numpy
-    - ccpi-viewer >= 22.2.0
+    - ccpi-viewer >=22.2.0
     - ccpi-dvc >=21.1.0
     - natsort
     - docopt


### PR DESCRIPTION
Closes #114
Also restricts ccpi-viewer version as newest version has some backward-incompatible changes 