### PR TITLE
Limit points in dvc config file.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## v22.x.x
 * Add basic color bar when visualising the vectors in both 2D and 3D
+* Pass max number of points to be processed to dvc executable
+* Pass point 0 location to dvc executable
+* Add button to set the number of points in the run to all points in the pointcloud.
 
 ## v22.1.0
 * Allows loading of TIFF stacks to run DVC code

--- a/src/idvc/dvc_interface.py
+++ b/src/idvc/dvc_interface.py
@@ -3563,6 +3563,18 @@ Try modifying the subvolume size before creating a new pointcloud, and make sure
         formLayout.setWidget(widgetno, QFormLayout.SpanningRole, separators[-1])
         widgetno += 1  
 
+        rdvc_widgets['run_all_points_label'] = QLabel(groupBox)
+        rdvc_widgets['run_all_points_label'].setText("Run all Points in cloud:")
+        rdvc_widgets['run_all_points_label'].setToolTip("Run all of the points in the pointcloud.")
+        formLayout.setWidget(widgetno, QFormLayout.LabelRole, rdvc_widgets['run_all_points_label'])
+
+        rdvc_widgets['run_all_points_entry'] = QtWidgets.QPushButton(groupBox)
+        rdvc_widgets['run_all_points_entry'].setText("Set all points")
+        formLayout.setWidget(widgetno, QFormLayout.FieldRole, rdvc_widgets['run_all_points_entry'])
+        rdvc_widgets['run_all_points_entry'].clicked.connect(self._set_num_points_in_run_to_all)
+
+        widgetno +=1
+
         rdvc_widgets['run_points_label'] = QLabel(groupBox)
         rdvc_widgets['run_points_label'].setText("Points in Run:")
         rdvc_widgets['run_points_label'].setToolTip("Run on a selection of the points in the pointcloud.")
@@ -3570,7 +3582,7 @@ Try modifying the subvolume size before creating a new pointcloud, and make sure
 
         rdvc_widgets['run_points_spinbox'] = QSpinBox(groupBox)
         rdvc_widgets['run_points_spinbox'].setMinimum(10)
-        # max should be the number in the point cloud
+        # max will be set to the number in the point cloud in DisplayNumberOfPointcloudPoints
         maxpoints = 10000
         rdvc_widgets['run_points_spinbox'].setMaximum(maxpoints)
         rdvc_widgets['run_points_spinbox'].setValue(100)
@@ -3814,6 +3826,14 @@ This parameter has a strong effect on computation time, so be careful."
         self.addDockWidget(QtCore.Qt.LeftDockWidgetArea, dockWidget)
 
         self.rdvc_widgets = rdvc_widgets
+
+    def _set_num_points_in_run_to_all(self):
+        int(self.pc_no_points)
+        if hasattr(self, 'pc_no_points'):
+            maxpoints = int(self.pc_no_points)
+        else:
+            maxpoints = 10000
+        self.rdvc_widgets['run_points_spinbox'].setValue(maxpoints)
 
     def show_run_groupbox(self):
         if self.rdvc_widgets['run_type_entry'].currentIndex() == 0:

--- a/src/idvc/dvc_interface.py
+++ b/src/idvc/dvc_interface.py
@@ -3999,7 +3999,7 @@ This parameter has a strong effect on computation time, so be careful."
 
             #where is point0
             run_config['point0'] = self.getPoint0ImageCoords()
-            # here we assume that the world coordinate are the same as the origina
+            # here we assume that the world coordinate are the same as the original
             # image coordinate because spacing is 1,1,1 and origin is 0,0,0 for the 
             # original input image
             run_config['point0_world_coordinate'] = self.point0_world_coords

--- a/src/idvc/dvc_interface.py
+++ b/src/idvc/dvc_interface.py
@@ -3999,6 +3999,10 @@ This parameter has a strong effect on computation time, so be careful."
 
             #where is point0
             run_config['point0'] = self.getPoint0ImageCoords()
+            # here we assume that the world coordinate are the same as the origina
+            # image coordinate because spacing is 1,1,1 and origin is 0,0,0 for the 
+            # original input image
+            run_config['point0_world_coordinate'] = self.point0_world_coords
             suffix_text = "run_config"
 
             self.run_config_file = os.path.join(tempfile.tempdir, "Results", folder_name, "_" + suffix_text + ".json")

--- a/src/idvc/dvc_runner.py
+++ b/src/idvc/dvc_runner.py
@@ -259,50 +259,26 @@ class DVC_runner(object):
             subvolume_size = int(subvolume_sizes[file_count])
             #print(roi_file)
             distances = []
-                
-            # with open(roi_file, "r") as entire_central_grid:
-                
-            #     for line in entire_central_grid:
-            #         line_array = line.split()
-
-            #         distance = np.sqrt(np.square(float(line_array[1]) - point0[0]) + \
-            #             np.square(float(line_array[2])-point0[1]) + np.square(float(line_array[3])-point0[2]))
-
-            #         distances.append(distance)
-                
-            # lines_to_write = []
-
-            # # sort the points in euclidean distance to the point0
-            # # add to the list of points to be run (selected_central_grid) by adding to 
-            # # the point list only the files with index in lines_to_write
-            # order = [ i for i in range(len(distances))]
-            # sorted_list_index = [ el for el in zip(distances, order)]
-            # sorted_list_index.sort()
-            # # this contains the indices of the sorted list
-            # lines_to_write = [ el for el in zip(*sorted_list_index) ] [1][:points]
 
             for subv_num, subvolume_point in enumerate(subvolume_points):
                 now = datetime.now()
                 # use a counter for both for loops
                 counter = subv_num + roi_num * len(subvolume_points)
-                # dt_string = now.strftime("%d%m%Y_%H%M%S")
-                # new_output_filename = "%s/dvc_result_%s" % (self.run_folder, dt_string)
-                # config_filename = "%s/dvc_config_%s" % (self.run_folder, dt_string)
-                # config_filename = config_filename + ".txt"
+                
                 this_run_folder = os.path.join(self.run_folder, "dvc_result_{}".format(counter))
                 os.mkdir(this_run_folder)
                 output_filename = os.path.join(this_run_folder, "dvc_result_{}".format(counter))
                 config_filename = os.path.join(this_run_folder,"dvc_config.txt")
                 
                 grid_roi_fname = os.path.join(this_run_folder, "grid_input.roi")
-                with open(grid_roi_fname,"w") \
-                    as selected_central_grid:
-                    with open(roi_file, "r") as entire_central_grid:
-                        for i,line in enumerate(entire_central_grid):
-                            # if i in lines_to_write:
-                            if True:
-                                selected_central_grid.write(line)
-
+                # copies the pointcloud file as a whole in the run directory
+                try:
+                    shutil.copyfile(roi_file, grid_roi_fname)
+                except Error as err:
+                    # this is not really a nice way to open an error message!
+                    mainwindow.displayFileErrorDialog(message=str(err), title="Error creating config files")
+                    return
+                
                 
                 config =  blank_config.format(
                     reference_filename=  reference_file, # reference tomography image volume

--- a/src/idvc/dvc_runner.py
+++ b/src/idvc/dvc_runner.py
@@ -65,6 +65,7 @@ rigid_trans		{rigid_trans}		### rigid body offset of target volume, in voxels
 basin_radius		{basin_radius}			### coarse-search resolution, in voxels, 0.0 = none
 subvol_aspect		{subvol_aspect}		### subvolume aspect ratio
 num_points_to_process   {num_points_to_process}  ### Number of points in the point cloud to process
+starting_point  {starting_point}    ### x,y,z location of starting point for DVC analysis
 '''
 
 def update_progress(main_window, process, total_points, required_runs, run_succeeded):
@@ -205,6 +206,7 @@ class DVC_runner(object):
         interp_type = config['interp_type']
 
         rigid_trans = config['rigid_trans']
+        starting_point = config['point0']
 
         # Change directory into the folder where the run will be saved:
         os.chdir(session_folder)
@@ -327,7 +329,8 @@ class DVC_runner(object):
                     rigid_trans= rigid_trans, #translation between ref and cor - determined from image registration
                     basin_radius='0.0',
                     subvol_aspect='1.0 1.0 1.0',# image spacing
-                    num_points_to_process=num_points_to_process) 
+                    num_points_to_process=num_points_to_process, 
+                    starting_point='{} {} {}'.format(*starting_point)) 
                 time.sleep(1)
                 with open(config_filename,"w") as config_file:
                     config_file.write(config)

--- a/src/idvc/dvc_runner.py
+++ b/src/idvc/dvc_runner.py
@@ -206,7 +206,7 @@ class DVC_runner(object):
         interp_type = config['interp_type']
 
         rigid_trans = config['rigid_trans']
-        starting_point = config['point0']
+        starting_point = config['point0_world_coordinate']
 
         # Change directory into the folder where the run will be saved:
         os.chdir(session_folder)
@@ -252,7 +252,7 @@ class DVC_runner(object):
 
 
         file_count = -1
-        point0 = main_window.getPoint0WorldCoords()
+        # point0 = main_window.getPoint0WorldCoords()
             
         for roi_num, roi_file in enumerate(roi_files):
             file_count +=1

--- a/src/idvc/dvc_runner.py
+++ b/src/idvc/dvc_runner.py
@@ -64,6 +64,7 @@ interp_type		{interp_type}		### trilinear, tricubic
 rigid_trans		{rigid_trans}		### rigid body offset of target volume, in voxels
 basin_radius		{basin_radius}			### coarse-search resolution, in voxels, 0.0 = none
 subvol_aspect		{subvol_aspect}		### subvolume aspect ratio
+num_points_to_process   {num_points_to_process}  ### Number of points in the point cloud to process
 '''
 
 def update_progress(main_window, process, total_points, required_runs, run_succeeded):
@@ -168,6 +169,7 @@ class DVC_runner(object):
         subvolume_points = config['subvolume_points'] 
         subvolume_sizes = config['subvolume_sizes']
         points = int(config['points'])
+        num_points_to_process = points
 
         roi_files = config['roi_files']
         reference_file = config['reference_file']
@@ -256,26 +258,26 @@ class DVC_runner(object):
             #print(roi_file)
             distances = []
                 
-            with open(roi_file, "r") as entire_central_grid:
+            # with open(roi_file, "r") as entire_central_grid:
                 
-                for line in entire_central_grid:
-                    line_array = line.split()
+            #     for line in entire_central_grid:
+            #         line_array = line.split()
 
-                    distance = np.sqrt(np.square(float(line_array[1]) - point0[0]) + \
-                        np.square(float(line_array[2])-point0[1]) + np.square(float(line_array[3])-point0[2]))
+            #         distance = np.sqrt(np.square(float(line_array[1]) - point0[0]) + \
+            #             np.square(float(line_array[2])-point0[1]) + np.square(float(line_array[3])-point0[2]))
 
-                    distances.append(distance)
+            #         distances.append(distance)
                 
-            lines_to_write = []
+            # lines_to_write = []
 
-            # sort the points in euclidean distance to the point0
-            # add to the list of points to be run (selected_central_grid) by adding to 
-            # the point list only the files with index in lines_to_write
-            order = [ i for i in range(len(distances))]
-            sorted_list_index = [ el for el in zip(distances, order)]
-            sorted_list_index.sort()
-            # this contains the indices of the sorted list
-            lines_to_write = [ el for el in zip(*sorted_list_index) ] [1][:points]
+            # # sort the points in euclidean distance to the point0
+            # # add to the list of points to be run (selected_central_grid) by adding to 
+            # # the point list only the files with index in lines_to_write
+            # order = [ i for i in range(len(distances))]
+            # sorted_list_index = [ el for el in zip(distances, order)]
+            # sorted_list_index.sort()
+            # # this contains the indices of the sorted list
+            # lines_to_write = [ el for el in zip(*sorted_list_index) ] [1][:points]
 
             for subv_num, subvolume_point in enumerate(subvolume_points):
                 now = datetime.now()
@@ -295,7 +297,8 @@ class DVC_runner(object):
                     as selected_central_grid:
                     with open(roi_file, "r") as entire_central_grid:
                         for i,line in enumerate(entire_central_grid):
-                            if i in lines_to_write:
+                            # if i in lines_to_write:
+                            if True:
                                 selected_central_grid.write(line)
 
                 
@@ -323,7 +326,8 @@ class DVC_runner(object):
                     interp_type=  interp_type, #tricubic for test image
                     rigid_trans= rigid_trans, #translation between ref and cor - determined from image registration
                     basin_radius='0.0',
-                    subvol_aspect='1.0 1.0 1.0') # image spacing
+                    subvol_aspect='1.0 1.0 1.0',# image spacing
+                    num_points_to_process=num_points_to_process) 
                 time.sleep(1)
                 with open(config_filename,"w") as config_file:
                     config_file.write(config)


### PR DESCRIPTION
This uses the new functionality of the DVC executable (https://github.com/vais-ral/CCPi-DVC/pull/159) to read the number of points to be processed in the config file, thereby removing the necessity to change the pointcloud in the interface.