### PR TITLE
Block dockwidgets

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # ChangeLog
 
 ## vx.x.x
+* Set QDockWidgets flag to NoDockWidgetFeatures to prevent them being moved or lost.
 * Add setting to set the number of OpenMP threads to use during DVC analysis
 * Use os.path.join to create all filepaths, previously in some cases we were forcing "\" or "/" to be in some paths
 * renames input files with names reference and correlate for the relative images, if data are copied in the session.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # ChangeLog
 
 ## vx.x.x
+* Set empty pop-up menus for the main windows
 * Set Tabified widgets not to move or close
 * Set QDockWidgets flag to NoDockWidgetFeatures to prevent them being moved or lost.
 * Consume events 'w' and 's' in viewers to avoid render changes between wireframe and surface respectively.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # ChangeLog
 
 ## vx.x.x
+* Set Tabified widgets not to move or close
 * Set QDockWidgets flag to NoDockWidgetFeatures to prevent them being moved or lost.
 * Consume events 'w' and 's' in viewers to avoid render changes between wireframe and surface respectively.
 * Added argument parser to idvc command. This allows the user to specify the debugging level.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,7 +48,7 @@ requirements:
     - matplotlib
     - openmp                # [osx]
     - qdarkstyle
-    - vtk=8.1.2
+    - vtk
 
 about:
   home: http://www.ccpi.ac.uk

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,6 +37,7 @@ requirements:
   build:
     - python
     - numpy
+    - typing_extensions # [py<=37]
 
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,7 +48,7 @@ requirements:
     - matplotlib
     - openmp                # [osx]
     - qdarkstyle
-    - vtk
+    - vtk=8.1.2
 
 about:
   home: http://www.ccpi.ac.uk

--- a/src/idvc/dvc_interface.py
+++ b/src/idvc/dvc_interface.py
@@ -26,7 +26,7 @@ from PySide2.QtWidgets import (QAction, QCheckBox, QComboBox,
                                QFrame, QGroupBox, QLabel, QLineEdit,
                                QMainWindow, QMessageBox,
                                QProgressDialog, QPushButton, QSpinBox,
-                               QTabWidget, QVBoxLayout,
+                               QTabWidget, QTabBar, QVBoxLayout,
                                QHBoxLayout, QSizePolicy,
                                QWidget)
 import time
@@ -184,6 +184,13 @@ class MainWindow(QMainWindow):
         else:
             self.CreateSessionSelector("new window")
 
+    def createPopupMenu(self):
+        '''return an empty menu for the main window to use as a popup menu.
+        
+        https://doc.qt.io/qt-6/qmainwindow.html#createPopupMenu
+        '''
+        return QtWidgets.QMenu(self) # Create a new menu
+    
     def SetAppStyle(self):
         if self.settings.value("dark_mode") is None:
             self.settings.setValue("dark_mode", True)
@@ -282,13 +289,12 @@ class MainWindow(QMainWindow):
                     first_dock = current_dock
                 prev= current_dock
                 docks.append(current_dock)
-                
-        first_dock.raise_() # makes first panel the one that is open by default.
+        
+        # makes first panel the one that is open by default.
+        first_dock.raise_()
 
         self.addDockWidget(QtCore.Qt.LeftDockWidgetArea, self.viewer3D_dock)
         
-
-
         # Make a window to house the right dockwidgets
         # This ensures the 2D viewer is large and allows us to position the help and settings below it
 
@@ -301,6 +307,10 @@ class MainWindow(QMainWindow):
         self.RightDockWindow.addDockWidget(QtCore.Qt.BottomDockWidgetArea,self.help_dock)
 
         self.RightDockWindow.addDockWidget(QtCore.Qt.BottomDockWidgetArea,self.viewer_settings_dock)
+
+        # Stop the widgets in the tab to be moved around
+        for wdg in self.findChildren(QTabBar):
+            wdg.setMovable(False)
         
 
     def CreateViewerSettingsPanel(self):
@@ -2383,6 +2393,7 @@ It is used as a global starting point and a translation reference."
     def CreatePointCloudPanel(self):
 
         self.pointCloudDockWidget = QDockWidget(self)
+        self.pointCloudDockWidget.setFeatures(QDockWidget.NoDockWidgetFeatures)
         self.pointCloudDockWidget.setWindowTitle('4 - Point Cloud')
         self.pointCloudDockWidget.setObjectName("PointCloudPanel")
         self.pointCloudDockWidgetContents = QWidget()

--- a/src/idvc/dvc_interface.py
+++ b/src/idvc/dvc_interface.py
@@ -1184,6 +1184,7 @@ It is used as a global starting point and a translation reference."
         
 
         reg_viewer_dock = QDockWidget("Image Registration",self.RightDockWindow)
+        reg_viewer_dock.setFeatures(QDockWidget.NoDockWidgetFeatures)
         reg_viewer_dock.setObjectName("2DRegView")
         reg_viewer_dock.setWidget(self.vis_widget_reg)
         #reg_viewer_dock.setMinimumHeight(self.size().height()*0.9)

--- a/src/idvc/dvc_interface.py
+++ b/src/idvc/dvc_interface.py
@@ -267,18 +267,13 @@ class MainWindow(QMainWindow):
         self.viewer3D_dock = QDockWidget("3D View")
         self.viewer3D_dock.setObjectName("3DImageView")
         self.viewer3D_dock.setWidget(self.vis_widget_3D)
-        self.viewer3D_dock.setAllowedAreas(Qt.LeftDockWidgetArea)
-        self.viewer3D_dock.setFeatures(QDockWidget.DockWidgetFloatable | 
-            QDockWidget.DockWidgetMovable)
-        
+        self.viewer3D_dock.setAllowedAreas(Qt.LeftDockWidgetArea)      
 
         #Tabifies dockwidgets in LeftDockWidgetArea:
         prev = None
         first_dock = None
         docks = []
         for current_dock in self.findChildren(QDockWidget):
-            current_dock.setFeatures(QDockWidget.DockWidgetFloatable | 
-                QDockWidget.DockWidgetMovable)
             if self.dockWidgetArea(current_dock) == QtCore.Qt.LeftDockWidgetArea:
                 if prev:
                     self.tabifyDockWidget(prev,current_dock)                    

--- a/src/idvc/dvc_interface.py
+++ b/src/idvc/dvc_interface.py
@@ -267,7 +267,8 @@ class MainWindow(QMainWindow):
         self.viewer3D_dock = QDockWidget("3D View")
         self.viewer3D_dock.setObjectName("3DImageView")
         self.viewer3D_dock.setWidget(self.vis_widget_3D)
-        self.viewer3D_dock.setAllowedAreas(Qt.LeftDockWidgetArea)      
+        self.viewer3D_dock.setAllowedAreas(Qt.LeftDockWidgetArea)
+        self.viewer3D_dock.setFeatures(QDockWidget.NoDockWidgetFeatures)   
 
         #Tabifies dockwidgets in LeftDockWidgetArea:
         prev = None

--- a/src/idvc/dvc_interface.py
+++ b/src/idvc/dvc_interface.py
@@ -1275,6 +1275,10 @@ It is used as a global starting point and a translation reference."
             self.createPoint0(p0l)
 
     def updatePoint0Display(self):
+        '''Updates the point 0 vtk.vtkCursor3D on the viewer to be centred
+        on the current value of self.point0_world_coords (returned by getPoint0WorldCoords()).
+        '''
+        #point0 , point0Mapper, point0Actor
         vox = self.getPoint0WorldCoords()
         for point0 in self.point0:
             point0[0].SetFocalPoint(*vox)
@@ -1346,8 +1350,12 @@ It is used as a global starting point and a translation reference."
                 self.registration_parameters['point_zero_entry'].setText(str([round(self.point0_sampled_image_coords[i]) for i in range(3)]))
 
     def centerOnPointZero(self):
-        #print("Center on point0")
-        '''Centers the viewing slice where Point 0 is'''
+        '''Centers the viewing slice on the registration viewer where Point 0 is.
+        This makes sure that the point 0 is visible on the viewer, in the slicing direction.
+        E.g. if point0 is at (5,6,7) and we are slicing in the Z direction, the viewer will 
+        display slice Z=7.
+        Produces a warning dialog if point0 has not yet been selected.
+        '''
         if hasattr(self, 'vis_widget_reg'):
             v = self.vis_widget_reg.frame.viewer
 
@@ -1445,6 +1453,11 @@ It is used as a global starting point and a translation reference."
         return reg_box_size
 
     def getRegistrationBoxExtentInWorldCoords(self):
+        '''
+        Sets self.registration_box_extent to the extent of the registration box in world coordinates.
+        The extent is a list of 6 values: [xmin, xmax, ymin, ymax, zmin, zmax]
+        Returns self.registration_box_extent
+        '''
         p0 = self.getPoint0WorldCoords()
         reg_box_size = self.getRegistrationBoxSizeInWorldCoords()
 
@@ -1478,11 +1491,25 @@ It is used as a global starting point and a translation reference."
         return p0
 
     def OnStartStopRegistrationPushed(self):
+        ''' This method is triggered by pressing the "Start Registration" button or the "Confirm Registration" button.
+        If "Start Registration" is pressed:
+        - the text on the button is changed to "Confirm Registration"
+        - the widgets for setting point0, the registration box size and the translation are disabled
+        - the size of the registration box may be updated to make sure it does not exceed the image extent
+        - sets up self.translate, which is a vtk.vtkImageTranslateExtent() object, with translation values linked to the values in the translation widgets
+        - calls LoadImagesAndCompleteRegistration()
+
+        
+        Alternatively if "Confirm Registration" is pressed:
+        - the text on the button is changed to "Start Registration"
+        - the widgets for setting point0, the registration box size and the translation are enabled
+        - the full dimension (possibly downsampled) reference image is displayed on the viewer.
+        '''
         if hasattr(self, 'vis_widget_reg'):
             self.UpdateViewerSettingsPanelForRegistration()
             rp = self.registration_parameters
             v = self.vis_widget_reg.frame.viewer
-            if rp['start_registration_button'].isChecked():
+            if rp['start_registration_button'].isChecked(): # "Start Registration" has been pressed
 
                 # check if we can make registration box, by checking
                 # if the size of registration box is smaller than the difference 
@@ -1519,7 +1546,7 @@ It is used as a global starting point and a translation reference."
                 self.LoadImagesAndCompleteRegistration()
                 
             
-            else:
+            else: # "Confirm Registration" has been pressed
                 # print ("Start Registration Unchecked")
                 rp['start_registration_button'].setText("Start Registration")
                 rp['registration_box_size_entry'].setEnabled(True)
@@ -1576,15 +1603,17 @@ It is used as a global starting point and a translation reference."
                 vs_widgets['loaded_image_dims_label'].setText("Original Image Size: ")
     
     def LoadImagesAndCompleteRegistration(self):
+        '''
+        1. Update self.unsampled_ref_image_data and self.unsampled_corr_image_data to contain the full resolution (unsampled) reference and correlate images,
+           cropped on the Z axis to the current registration box extent.
+        2. Run self.completeRegistration()
+        '''
 
         if hasattr(self, 'registration_box_extent'):
             previous_reg_box_extent = copy.deepcopy(self.registration_box_extent)
-            # print("Prev", previous_reg_box_extent)
         else:
             previous_reg_box_extent = None
 
-        reg_box_size = self.getRegistrationBoxSizeInWorldCoords()
-        point0 = self.getPoint0WorldCoords()
         reg_box_extent = self.getRegistrationBoxExtentInWorldCoords()
 
         target_z_extent = [reg_box_extent[4], reg_box_extent[5]]
@@ -1610,7 +1639,7 @@ It is used as a global starting point and a translation reference."
                 #TODO: move to doing both image data creators simultaneously - would this work?
                 return
 
-            if previous_reg_box_extent != reg_box_extent:
+            if previous_reg_box_extent != reg_box_extent: # If registration box is changed need to update the cropped images.
                 ImageDataCreator.createImageData(self, self.image[0], self.unsampled_ref_image_data, info_var=self.unsampled_image_info, crop_image=True, origin=origin,
                                                  target_z_extent=target_z_extent, output_dir=os.path.abspath(tempfile.tempdir), finish_fn=self.LoadCorrImageForReg, crop_corr_image=True)
             else:
@@ -1625,6 +1654,11 @@ It is used as a global starting point and a translation reference."
                 self.completeRegistration()
 
     def LoadCorrImageForReg(self,resample_corr_image= False, crop_corr_image = False): 
+        '''
+        Loads the full resolution correlate image, cropped on the Z axis to the current registration box extent.
+        Saves the result in self.unsampled_corr_image_data.
+        Then runs self.completeRegistration()
+        '''
         origin = self.target_cropped_image_origin 
         z_extent = self.target_cropped_image_z_extent
 
@@ -1633,6 +1667,12 @@ It is used as a global starting point and a translation reference."
                                          crop_image=crop_corr_image, origin=origin, target_z_extent=z_extent, finish_fn=self.completeRegistration, output_dir=os.path.abspath(tempfile.tempdir))
 
     def completeRegistration(self):
+        '''
+        1. Updates the point0 widget on the viewer to be centred on the location selected by the user.
+        2. Translates the correlate image by the translation values set in the translation widgets, and subtracts the reference image from the translated correlate image.
+        3. Updates the viewer to display the result of the subtraction.
+        4. Centres the viewer on the slice that contains point 0.
+        '''
         self.updatePoint0Display()
         self.translateImages()
         self.reg_viewer_update(type = 'starting registration')
@@ -1664,6 +1704,11 @@ It is used as a global starting point and a translation reference."
 
 
     def translateImages(self, progress_callback = None):
+        '''
+        Subtracts the reference image from the translated correlate image. Result is saved in self.subtract
+        To do this the images must be cast to float first, and self.cast contains a list of the vtkImageCast
+        objects set up for the reference and correlate images. 
+        '''
         #progress_callback.emit(10)
         data = self.getRegistrationVOIs()
         data1 = data[0]
@@ -1741,6 +1786,18 @@ It is used as a global starting point and a translation reference."
 
 
     def reg_viewer_update(self, type = None):
+        '''
+        Updates the translation widgets with the current translation on each axis.
+        Updates the registration viewer to display the result of the difference between
+        the reference and translated correlate image.
+
+        Parameters
+        ----------
+        type : str
+            If 'starting registration' then the registration viewer is centred on the slice that contains point 0.
+            This is the case if the "Start Registration" button is pressed. Otherwise, when type=None we are in the middle of 
+            manual registration and the viewer is centred on the current slice
+        '''
         # print("Reg viewer update")
         # update the current translation on the interface:
         rp = self.registration_parameters

--- a/src/idvc/ui/windows.py
+++ b/src/idvc/ui/windows.py
@@ -250,3 +250,7 @@ class GraphsWindow(QMainWindow):
 
         dock.raise_() # makes summary panel the one that is open by default.
 
+        # Stop the widgets in the tab to be moved around
+        for wdg in self.findChildren(QTabBar):
+            wdg.setMovable(False)
+

--- a/src/idvc/ui/windows.py
+++ b/src/idvc/ui/windows.py
@@ -227,6 +227,7 @@ class GraphsWindow(QMainWindow):
     
             GraphWidget = SingleRunResultsWidget(self, result, displ_wrt_point0)
             dock1 = QDockWidget(result.title,self)
+            dock1.setFeatures(QDockWidget.NoDockWidgetFeatures) 
             dock1.setAllowedAreas(QtCore.Qt.RightDockWidgetArea)
             dock1.setWidget(GraphWidget)
             self.addDockWidget(QtCore.Qt.RightDockWidgetArea,dock1)
@@ -243,6 +244,7 @@ class GraphsWindow(QMainWindow):
         
         SummaryTab = SummaryGraphsWidget(self, result_list)
         dock = QDockWidget("Summary",self)
+        dock.setFeatures(QDockWidget.NoDockWidgetFeatures) 
         dock.setAllowedAreas(QtCore.Qt.RightDockWidgetArea)
         dock.setWidget(SummaryTab)
         self.addDockWidget(QtCore.Qt.RightDockWidgetArea,dock)

--- a/src/idvc/ui/windows.py
+++ b/src/idvc/ui/windows.py
@@ -30,6 +30,13 @@ class VisualisationWindow(QtWidgets.QMainWindow):
         self.parent = parent
         self.setMinimumSize(200,200)
 
+    def createPopupMenu(self):
+        '''returns an empty menu for the main window to use as a popup menu.
+        
+        https://doc.qt.io/qt-6/qmainwindow.html#createPopupMenu
+        '''
+        return QtWidgets.QMenu(self)
+    
 class VisualisationWidget(QtWidgets.QMainWindow):
     '''creates a window with a QCILViewerWidget as the central widget
     '''
@@ -55,8 +62,7 @@ class VisualisationWidget(QtWidgets.QMainWindow):
 
     def getViewerType(self):
         return self.viewer
-
-        
+     
     def createEmptyFrame(self):
         #print("empty")
         self.frame = QCILViewerWidget(viewer=self.viewer, shape=(600,600), interactorStyle=self.interactorStyle)

--- a/src/idvc/utilities.py
+++ b/src/idvc/utilities.py
@@ -74,6 +74,7 @@ def generateUIDockParameters(self, title): #copied from dvc_configurator.py
     self.addDockWidget(QtCore.Qt.RightDockWidgetArea, dockWidget)
     '''
     dockWidget = QDockWidget(self)
+    dockWidget.setFeatures(QDockWidget.NoDockWidgetFeatures)
     dockWidget.setWindowTitle(title)
     dockWidgetContents = QWidget()
 


### PR DESCRIPTION
Uses flag `NoDockWidgetFeatures` which prevents a lot of complications in handling `QDockWidgets` and makes the GUI more static.

- Set movable to `False` in tabified `DockWidget`s both in the main window and in the result window.
- Remove default `popupMenu` by overloading `createPopupMenu`, i.e. removes the weird list of the tabs which were in a pseudo-random order. This is done both in the app main window and the right hand side main window.
- During the registration, the "Image Registration" tab appears. This is no longer floatable, movable and closable.

The 2D viewer widget appears to be a `QMainWindow` and not a `QDockWidget`, hence I don't exactly know how to set the title. I tried with `setWindowTitle` but it doesn't show up. https://github.com/TomographicImaging/iDVC/blob/1eae74768ef7f625fbff9042055172dfe188a4b0/src/idvc/ui/windows.py#L33


Closes #174 
Closes #178

Tested on Windows.