### PR TITLE
Enable loading TIFF with float or 32 bits

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # ChangeLog
 
 ## vx.x.x
+* Enable loading of TIFF files with non integer pixel values. Data will be rescaled to uint16 (#228)
 * Set empty pop-up menus for the main windows
 * Set Tabified widgets not to move or close
 * Set QDockWidgets flag to NoDockWidgetFeatures to prevent them being moved or lost.

--- a/src/idvc/dvc_runner.py
+++ b/src/idvc/dvc_runner.py
@@ -242,6 +242,10 @@ class DVC_runner(object):
 
         message_callback.emit("Creating run configurations")
         vol_bit_depth = int(config['vol_bit_depth'])
+        if vol_bit_depth not in ['8', '16']:
+            # the data will be converted to 16 bit by save_tiff_stack_as_raw
+            # it won't work with other formats
+            vol_bit_depth = 16
         vol_hdr_lngth = int(config['vol_hdr_lngth'])
 
         if 'vol_endian' in config:

--- a/src/idvc/dvc_runner.py
+++ b/src/idvc/dvc_runner.py
@@ -203,6 +203,40 @@ class DVC_runner(object):
         self.session_folder = session_folder
 
     def set_up(self, *args, **kwargs):
+        '''This function sets up the DVC run, creating the run configurations and setting up the run folders.
+        
+        Parameters:
+        -----------
+        *args: not used
+        **kwargs: 
+            message_callback: callback function for messages
+            progress_callback: callback function for progress updates
+
+        Returns:
+        --------
+        None
+
+        This function reads a json file containing the run configuration and creates the run configurations.
+        The json file contains the following:
+        - subvolume_points: list of number of points to process at each subvolume
+        - subvolume_sizes: list of subvolume sizes, if not an integer multiple runs will be created
+        - points: number of points to process in the point cloud
+        - roi_files: list of point cloud files
+        - reference_file: reference image volume
+        - correlate_file: correlation image volume
+        - vol_bit_depth: bit depth of the image volumes. If loading an image not of type int8 or int16, the image will be converted to uint16.
+        - vol_hdr_lngth: header length of the image volumes
+        - dims: dimensions of the image volumes
+        - subvol_geom: geometry of the subvolume, either cube or sphere
+        - subvol_npts: number of points in the subvolume, not used
+        - disp_max: maximum displacement in voxels
+        - dof: number of parameters in the optimisation, 3,6, or 12
+        - obj: objective function, either sad, ssd, zssd, nssd, or znssd
+        - interp_type: interpolation type, either trilinear or tricubic
+        - run_folder: folder to save the run results and configurations
+        - rigid_trans: rigid translation between the reference and correlation volumes
+        - point0_world_coordinate: world coordinates of the starting point for the DVC analysis
+        '''
 
         self.processes = []
         self.process_num = 0

--- a/src/idvc/io.py
+++ b/src/idvc/io.py
@@ -487,7 +487,7 @@ def loadTif(*args, **kwargs):
     target_size = kwargs.get('target_size', 0.125)
     origin = kwargs.get('origin', (0, 0, 0))
     target_z_extent = kwargs.get('target_z_extent', (0, 0))
-    bits_per_byte = 8
+    bits_per_byte = 16
 
     # time.sleep(0.1) #required so that progress window displays
     # progress_callback.emit(10)
@@ -530,36 +530,9 @@ def loadTif(*args, **kwargs):
             getProgress, progress_callback=progress_callback))
         reader.SetFileName(filenames)
 
-        dtype = vtk.VTK_UNSIGNED_CHAR
+        
 
-        if reader.GetOutput().GetScalarType() != dtype and False:
-            # need to cast to 8 bits unsigned
-            print("The if statement is true")
-
-            stats = vtk.vtkImageAccumulate()
-            stats.SetInputConnection(reader.GetOutputPort())
-            stats.Update()
-            iMin = stats.GetMin()[0]
-            iMax = stats.GetMax()[0]
-            if (iMax - iMin == 0):
-                scale = 1
-            else:
-                scale = vtk.VTK_UNSIGNED_CHAR_MAX / (iMax - iMin)
-
-            shiftScaler = vtk.vtkImageShiftScale()
-            shiftScaler.SetInputConnection(reader.GetOutputPort())
-            shiftScaler.SetScale(scale)
-            shiftScaler.SetShift(-iMin)
-            shiftScaler.SetOutputScalarType(dtype)
-            shiftScaler.Update()
-
-            tmpdir = tempfile.gettempdir()
-            writer = vtk.vtkMetaImageWriter()
-            writer.SetInputConnection(shiftScaler.GetOutputPort())
-            writer.SetFileName(os.path.join(tmpdir, 'input8bit.mhd'))
-            writer.Write()
-
-            reader = shiftScaler
+        
         reader.Update()
 
         shape = reader.GetStoredArrayShape()
@@ -1019,6 +992,11 @@ def save_tiff_stack_as_raw(filenames: list, output_fname: str, progress_callback
             reader.SetFileName(el)
             reader.Update()
             slice_data = Converter.vtk2numpy(reader.GetOutput())
+            if slice_data.dtype not in [numpy.uint8, numpy.uint16]:
+                # scale to uint16
+                m,M = slice_data.min(), slice_data.max()
+                slice_data = (slice_data - m) / (M - m) * 65535
+                slice_data = slice_data.astype(numpy.uint16)
             f.write(slice_data.tobytes())
             progress_callback.emit(int(start_progress + (end_progress - start_progress) * (filenames.index(el) / steps)))
             

--- a/src/idvc/io.py
+++ b/src/idvc/io.py
@@ -992,10 +992,14 @@ def save_tiff_stack_as_raw(filenames: list, output_fname: str, progress_callback
             reader.SetFileName(el)
             reader.Update()
             slice_data = Converter.vtk2numpy(reader.GetOutput())
-            if slice_data.dtype not in [numpy.uint8, numpy.uint16]:
+            if slice_data.dtype not in [numpy.uint8, numpy.uint16, numpy.int8, numpy.int16]:
                 # scale to uint16
+                convert_to_dtype = numpy.uint16
+                # rescale as float32
+                slice_data = slice_data.astype(numpy.float32)
                 m,M = slice_data.min(), slice_data.max()
-                slice_data = (slice_data - m) / (M - m) * 65535
+                slice_data = (slice_data - m) / (M - m) * numpy.iinfo(convert_to_dtype).max 
+                # finally cast to uint16
                 slice_data = slice_data.astype(numpy.uint16)
             f.write(slice_data.tobytes())
             progress_callback.emit(int(start_progress + (end_progress - start_progress) * (filenames.index(el) / steps)))

--- a/src/idvc/io.py
+++ b/src/idvc/io.py
@@ -983,7 +983,9 @@ def generateMetaImageHeader(datafname, typecode, shape, isFortran, isBigEndian, 
     return header
 
 def save_tiff_stack_as_raw(filenames: list, output_fname: str, progress_callback, start_progress, end_progress) ->None :
-    '''Converts a TIFF stack to a raw file'''
+    '''Converts a TIFF stack to a raw file
+    
+    if the data is not uint8 or uint16, it will be scaled to uint16'''
     reader = vtk.vtkTIFFReader()
     reader.SetOrientationType(1) # TopLeft
     with open(os.path.abspath(output_fname), 'wb') as f:


### PR DESCRIPTION
Only TIFFs with char and shorts are handled correctly.

This PR allows the user to load non char/short int or float TIFF files.
In case of floats these will be rescaled to the full short range.