### PR TITLE
Add scrolling widget in the help text

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,6 @@
 
 ## vx.x.x
 * Add scrolling widget in the help text #260
-* Fix some missing pip dependencies & update workflows & fix tests #233
 * Add `openpyxl` to recipe files #262
 * Allow csv and xlxs formats in point-cloud file & add error dialog #262 
 * Set registration-box-size default and help text #259
@@ -10,7 +9,7 @@
 * Edit README.md to include Prof. Bay citations and ref to DVC executable #255
 * Edit "degrees of freedom" widget to be "optimisation parameters" #254
 * Enable loading of TIFF files with non integer pixel values. Data will be rescaled to uint16 #228
-* fix some missing pip dependencies & update workflows & fix tests #233
+* Fix some missing pip dependencies & update workflows & fix tests #233
 * Edit registration-tab name from "Manual" to "Initial" #241
 * Add automatic registration functionality #304
 * Set empty pop-up menus for the main windows #217

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,8 @@
 # ChangeLog
 
 ## vx.x.x
-* fix some missing pip dependencies & update workflows & fix tests #233
+* Add scrolling widget in the help text #260
+* Fix some missing pip dependencies & update workflows & fix tests #233
 * Edit registration-tab name from "Manual" to "Initial" #241
 * Add automatic registration functionality #304
 * Set empty pop-up menus for the main windows #217

--- a/src/idvc/dvc_interface.py
+++ b/src/idvc/dvc_interface.py
@@ -25,10 +25,10 @@ from PySide2.QtWidgets import (QAction, QCheckBox, QComboBox,
                                QDoubleSpinBox, QFileDialog, QFormLayout,
                                QFrame, QGroupBox, QLabel, QLineEdit,
                                QMainWindow, QMessageBox,
-                               QProgressDialog, QPushButton, QSpinBox,
+                               QProgressDialog, QPushButton, QScrollArea, QSpinBox,
                                QTabWidget, QTabBar, QVBoxLayout,
                                QHBoxLayout, QSizePolicy,
-                               QWidget)
+                               QWidget) 
 import time
 import numpy as np
 import math
@@ -406,6 +406,10 @@ class MainWindow(QMainWindow):
                     viewer.updatePipeline()
 
     def CreateHelpPanel(self):
+        """Creates the help-text dock widget.
+        
+        Saves the help text for all tabs.
+        Adds a QLabel in the form of scrollable text."""
         help_panel = generateUIDockParameters(self, "Help")
         dockWidget = help_panel[0]
         dockWidget.setObjectName("HelpPanel")
@@ -444,9 +448,19 @@ class MainWindow(QMainWindow):
             "You may also scale the vectors to make them larger and easier to view.")
 
         self.help_label = QLabel(groupBox)
+        scroll_area_widget = QScrollArea()
+        
         self.help_label.setWordWrap(True)
         self.help_label.setText(self.help_text[0])
-        formLayout.setWidget(1, QFormLayout.SpanningRole, self.help_label)
+
+        scroll_area_widget.setWidget(self.help_label)
+        scroll_area_widget.setFrameShape(QFrame.NoFrame)
+        scroll_area_widget.setFrameShadow(QFrame.Plain)
+        scroll_area_widget.setStyleSheet("border: 0px;")
+        scroll_area_widget.setWidgetResizable(True)
+
+
+        formLayout.setWidget(1, QFormLayout.SpanningRole, scroll_area_widget)
 
     def displayHelp(self, open, panel_no = None):
         if open:


### PR DESCRIPTION
- Add scrolling widget in the help text

Closes #258 

Help text look:
![help_text_slider1](https://github.com/TomographicImaging/iDVC/assets/138598662/79ab7acd-0ed2-4f9e-a0bf-883e0583cc35)
![help_text_slider2](https://github.com/TomographicImaging/iDVC/assets/138598662/65454b1c-4f99-493d-ae7d-1b4ad94d4935)
