### PR TITLE
Upgrade iDVC to CILViewer 24.0.0

### DIFF
--- a/.github/workflows/conda_build_and_publish.yml
+++ b/.github/workflows/conda_build_and_publish.yml
@@ -15,7 +15,7 @@ jobs:
       with:
         additional_apt_packages: libgl-dev
         subDir: recipe
-        channels: '-c conda-forge -c ccpi -c paskino'
+        channels: '-c conda-forge -c ccpi'
         AnacondaToken: ${{ secrets.ANACONDA_TOKEN }}
         publish: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') }}
         test_all: ${{(github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')) || (github.ref == 'refs/heads/master')}}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # ChangeLog
 
 ## vx.x.x
+* Upgrade CILviewer to 24.0.0 #279
 * Fix vtk version #291
 * Disables buttons in Select-Image tab after first registration #293
 * Edit DVC-Results tab #231

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,7 +40,6 @@ Bug fixes:
   
 CI:
 * Upgrade CILviewer to 24.0.0 #279
-* Fix vtk version #291
 * Add `openpyxl` to recipe files #262
 * Fix some missing pip dependencies & update workflows & fix tests #233
 * Add build directory to gitignore #216

--- a/recipe/dev_environment.yml
+++ b/recipe/dev_environment.yml
@@ -15,4 +15,4 @@ dependencies:
     - matplotlib
     - openmp                # [osx]
     - qdarkstyle
-    - vtk =8.1.2
+    - vtk

--- a/recipe/dev_environment.yml
+++ b/recipe/dev_environment.yml
@@ -4,7 +4,7 @@ channels:
   - ccpi
 dependencies:   
     - openpyxl
-    - python =3.11
+    - python
     - numpy
     - scipy
     - ccpi::ccpi-viewer >=24.0.0

--- a/recipe/dev_environment.yml
+++ b/recipe/dev_environment.yml
@@ -1,8 +1,7 @@
 name: idvc_dev
 channels:
-  - ccpi
-  - paskino
   - conda-forge
+  - ccpi
 dependencies:   
     - openpyxl
     - python

--- a/recipe/dev_environment.yml
+++ b/recipe/dev_environment.yml
@@ -4,7 +4,7 @@ channels:
   - ccpi
 dependencies:   
     - openpyxl
-    - python
+    - python =3.11
     - numpy
     - scipy
     - ccpi::ccpi-viewer >=24.0.0

--- a/recipe/dev_environment.yml
+++ b/recipe/dev_environment.yml
@@ -8,7 +8,7 @@ dependencies:
     - python
     - numpy
     - scipy
-    - ccpi::ccpi-viewer >=22.2.0
+    - ccpi::ccpi-viewer >=24.0.0
     - ccpi::ccpi-dvc >=22.0.0
     - natsort
     - docopt

--- a/recipe/idvc_environment.yml
+++ b/recipe/idvc_environment.yml
@@ -1,7 +1,6 @@
 name: idvc
 channels:
-  - ccpi
-  - paskino
   - conda-forge
+  - ccpi
 dependencies:    
     - idvc

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,8 +38,8 @@ requirements:
     - python
     - numpy
     - scipy
-    - ccpi-viewer >=24.0.0
-    - ccpi-dvc >=22.0.0
+    - ccpi::ccpi-viewer >=24.0.0
+    - ccpi::ccpi-dvc >=22.0.0
     - natsort
     - docopt
     - matplotlib

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,12 +30,12 @@ test:
 
 requirements:
   build:
-    - python =3.11
+    - python
     - numpy
     - typing_extensions # [py<=37]
   run:
     - openpyxl
-    - python =3.11
+    - python
     - numpy
     - scipy
     - ccpi::ccpi-viewer >=24.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,7 +45,7 @@ requirements:
     - matplotlib
     - openmp                # [osx]
     - qdarkstyle
-    - vtk =8.1.2
+    - vtk
 
 about:
   home: http://www.ccpi.ac.uk

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ requirements:
     - python
     - numpy
     - scipy
-    - ccpi-viewer >=22.4.0
+    - ccpi-viewer >=24.0.0
     - ccpi-dvc >=22.0.0
     - natsort
     - docopt

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,7 @@ requirements:
     - typing_extensions # [py<=37]
   run:
     - openpyxl
-    - python
+    - python =3.11
     - numpy
     - scipy
     - ccpi::ccpi-viewer >=24.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,7 @@ test:
 
 requirements:
   build:
-    - python
+    - python =3.11
     - numpy
     - typing_extensions # [py<=37]
   run:

--- a/src/idvc/dvc_interface.py
+++ b/src/idvc/dvc_interface.py
@@ -1243,7 +1243,7 @@ It is used as a global starting point and a translation reference."
         self.orientation = self.vis_widget_2D.frame.viewer.getSliceOrientation()
         self.current_slice = self.vis_widget_2D.frame.viewer.getActiveSlice()
 
-        self.vis_widget_reg = VisualisationWidget(self, viewer2D)
+        self.vis_widget_reg = VisualisationWidget(parent = self, viewer = viewer2D, enableSliderWidget=False)
         
 
         reg_viewer_dock = QDockWidget("Image Registration",self.RightDockWindow)

--- a/src/idvc/ui/windows.py
+++ b/src/idvc/ui/windows.py
@@ -40,13 +40,13 @@ class VisualisationWindow(QtWidgets.QMainWindow):
 class VisualisationWidget(QtWidgets.QMainWindow):
     '''creates a window with a QCILViewerWidget as the central widget
     '''
-    def __init__(self, parent, viewer=viewer2D, interactorStyle=vlink.Linked2DInteractorStyle):
+    def __init__(self, parent, viewer=viewer2D, interactorStyle=vlink.Linked2DInteractorStyle, enableSliderWidget=True):
         super().__init__()
         self.parent = parent
-
         self.e = ErrorObserver()
         self.viewer = viewer
         self.interactorStyle = interactorStyle
+        self.enableSliderWidget = enableSliderWidget
         self.createEmptyFrame()
         self.threadpool = QThreadPool()
         self._consume_CharEvent = ['s', 'w']
@@ -65,7 +65,7 @@ class VisualisationWidget(QtWidgets.QMainWindow):
      
     def createEmptyFrame(self):
         #print("empty")
-        self.frame = QCILViewerWidget(viewer=self.viewer, shape=(600,600), interactorStyle=self.interactorStyle)
+        self.frame = QCILViewerWidget(parent = None, viewer=self.viewer, shape=(600,600), interactorStyle=self.interactorStyle, enableSliderWidget = self.enableSliderWidget)
         self.setCentralWidget(self.frame)
         self.image_file = [""]
        


### PR DESCRIPTION
WIP 
- Changed recipe, edit viewer version and deleted paskino channel.
- Tested on magma data all the tabs
- Changed the parameters in the class VisualisationWidget to include the enable/disable slider 
- Edited the parameters in the registration viewer creation to match the  new requirements in CILViewer

Note:
- When PR #291 was merged, the conda build failed as this PR is not compatible with vtk 8.

Hence, PR #295 fixed the problems with vtk 9. 

- [ ] PR not passing conda build