### PR TITLE
Improve dock widgets look

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 # ChangeLog
 
 ## vx.x.x
-* Make 3D viewer dock widget floatable, add minimum height. Add scroll area to dock widgets #289
+* Make 3D viewer dock widget floatable, add minimum height. Add scroll area to point-cloud tab #289
 * Edit DVC-Results tab #231
 * Edit mask help text and documentation #257
 * Scales the displacement vectors keeping the color bar with the displacement values. Adds title to color bar #270

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # ChangeLog
 
 ## vx.x.x
+* Make 3D viewer dock widget floatable, add minimum height. Add scroll area to dock widgets #289
 * Edit DVC-Results tab #231
 * Edit mask help text and documentation #257
 * Scales the displacement vectors keeping the color bar with the displacement values. Adds title to color bar #270

--- a/src/idvc/dvc_interface.py
+++ b/src/idvc/dvc_interface.py
@@ -469,11 +469,19 @@ class MainWindow(QMainWindow):
             "You may also scale the vectors to make them larger and easier to view.")
 
         self.help_label = QLabel(groupBox)
+        scroll_area_widget = QScrollArea()
     
         self.help_label.setWordWrap(True)
         self.help_label.setText(self.help_text[0])
 
-        formLayout.setWidget(1, QFormLayout.SpanningRole, self.help_label)
+        scroll_area_widget.setWidget(self.help_label)
+        scroll_area_widget.setFrameShape(QFrame.NoFrame)
+        scroll_area_widget.setFrameShadow(QFrame.Plain)
+        scroll_area_widget.setStyleSheet("border: 0px;")
+        scroll_area_widget.setWidgetResizable(True)
+
+
+        formLayout.setWidget(1, QFormLayout.SpanningRole, scroll_area_widget)
 
     def displayHelp(self, open, panel_no = None):
         if open:

--- a/src/idvc/dvc_interface.py
+++ b/src/idvc/dvc_interface.py
@@ -2615,12 +2615,14 @@ It is used as a global starting point and a translation reference."
         self.graphDockVL = QVBoxLayout(self.pointCloudDockWidgetContents)
         self.graphDockVL.setContentsMargins(0, 0, 0, 0)
 
-        scroll_area_point_cloud = QScrollArea()
-        scroll_area_point_cloud.setWidgetResizable(True)
-        scroll_area_point_cloud.setWidget(self.pointCloudDockWidgetContents)
+        
 
         # Create widget for dock contents
         self.dockWidget = QWidget(self.pointCloudDockWidgetContents)
+
+        scroll_area_point_cloud = QScrollArea()
+        scroll_area_point_cloud.setWidgetResizable(True)
+        scroll_area_point_cloud.setWidget(self.dockWidget)
 
         # Add vertical layout to dock widget
         self.graphWidgetVL = QVBoxLayout(self.dockWidget)
@@ -2888,8 +2890,8 @@ A 3D pointcloud is created within the full extent of the mask.")
         widgetno += 1
         # Add elements to layout
         self.graphWidgetVL.addWidget(self.graphParamsGroupBox)
-        self.graphDockVL.addWidget(self.dockWidget)
-        self.pointCloudDockWidget.setWidget(scroll_area_point_cloud)
+        self.graphDockVL.addWidget(scroll_area_point_cloud)
+        self.pointCloudDockWidget.setWidget(self.pointCloudDockWidgetContents)
         self.addDockWidget(QtCore.Qt.LeftDockWidgetArea, self.pointCloudDockWidget)
         widgetno += 1
 

--- a/src/idvc/dvc_interface.py
+++ b/src/idvc/dvc_interface.py
@@ -469,19 +469,11 @@ class MainWindow(QMainWindow):
             "You may also scale the vectors to make them larger and easier to view.")
 
         self.help_label = QLabel(groupBox)
-        scroll_area_widget = QScrollArea()
-        
+    
         self.help_label.setWordWrap(True)
         self.help_label.setText(self.help_text[0])
 
-        scroll_area_widget.setWidget(self.help_label)
-        scroll_area_widget.setFrameShape(QFrame.NoFrame)
-        scroll_area_widget.setFrameShadow(QFrame.Plain)
-        scroll_area_widget.setStyleSheet("border: 0px;")
-        scroll_area_widget.setWidgetResizable(True)
-
-
-        formLayout.setWidget(1, QFormLayout.SpanningRole, scroll_area_widget)
+        formLayout.setWidget(1, QFormLayout.SpanningRole, self.help_label)
 
     def displayHelp(self, open, panel_no = None):
         if open:

--- a/src/idvc/dvc_interface.py
+++ b/src/idvc/dvc_interface.py
@@ -2181,15 +2181,10 @@ It is used as a global starting point and a translation reference."
         formLayout.setWidget(widgetno, QFormLayout.FieldRole, mp_widgets['mask_extend_below_entry'])
         widgetno += 1
 
-        mp_widgets['mask_downsampled_coords_warning'] = QScrollArea()
-        qlabel = QLabel(groupBox)
-        qlabel.setWordWrap(True)
-        mp_widgets['mask_downsampled_coords_warning'].setWidget(qlabel)
-        mp_widgets['mask_downsampled_coords_warning'].setFrameShape(QFrame.NoFrame)
-        mp_widgets['mask_downsampled_coords_warning'].setFrameShadow(QFrame.Plain)
-        mp_widgets['mask_downsampled_coords_warning'].setStyleSheet("border: 0px;")
-        mp_widgets['mask_downsampled_coords_warning'].setWidgetResizable(True)
-        qlabel.setText("Note: if your image has been downsampled, the number of slices is in the coordinates of the downsampled image.")
+        mp_widgets['mask_downsampled_coords_warning'] = QLabel(groupBox)
+        mp_widgets['mask_downsampled_coords_warning'].setWordWrap(True)
+        mp_widgets['mask_downsampled_coords_warning'].setAutoFillBackground(False)
+        mp_widgets['mask_downsampled_coords_warning'].setText("Note: if your image has been downsampled, the number of slices is in the coordinates of the downsampled image.")
         formLayout.setWidget(widgetno, QFormLayout.FieldRole, mp_widgets['mask_downsampled_coords_warning'])
         widgetno += 1
 

--- a/src/idvc/dvc_interface.py
+++ b/src/idvc/dvc_interface.py
@@ -277,9 +277,10 @@ class MainWindow(QMainWindow):
 
         self.viewer3D_dock = QDockWidget("3D View")
         self.viewer3D_dock.setObjectName("3DImageView")
+        self.viewer3D_dock.setMinimumHeight(300)
         self.viewer3D_dock.setWidget(self.vis_widget_3D)
         self.viewer3D_dock.setAllowedAreas(Qt.LeftDockWidgetArea)
-        self.viewer3D_dock.setFeatures(QDockWidget.NoDockWidgetFeatures)   
+        self.viewer3D_dock.setFeatures(QDockWidget.DockWidgetFloatable)   
 
         #Tabifies dockwidgets in LeftDockWidgetArea:
         prev = None
@@ -2607,7 +2608,6 @@ It is used as a global starting point and a translation reference."
 # Point Cloud Panel:
 
     def CreatePointCloudPanel(self):
-
         self.pointCloudDockWidget = QDockWidget(self)
         self.pointCloudDockWidget.setFeatures(QDockWidget.NoDockWidgetFeatures)
         self.pointCloudDockWidget.setWindowTitle('4 - Point Cloud')
@@ -2618,8 +2618,13 @@ It is used as a global starting point and a translation reference."
 
 
         # Add vertical layout to dock contents
+
         self.graphDockVL = QVBoxLayout(self.pointCloudDockWidgetContents)
         self.graphDockVL.setContentsMargins(0, 0, 0, 0)
+
+        scroll_area_point_cloud = QScrollArea()
+        scroll_area_point_cloud.setWidgetResizable(True)
+        scroll_area_point_cloud.setWidget(self.pointCloudDockWidgetContents)
 
         # Create widget for dock contents
         self.dockWidget = QWidget(self.pointCloudDockWidgetContents)
@@ -2891,7 +2896,7 @@ A 3D pointcloud is created within the full extent of the mask.")
         # Add elements to layout
         self.graphWidgetVL.addWidget(self.graphParamsGroupBox)
         self.graphDockVL.addWidget(self.dockWidget)
-        self.pointCloudDockWidget.setWidget(self.pointCloudDockWidgetContents)
+        self.pointCloudDockWidget.setWidget(scroll_area_point_cloud)
         self.addDockWidget(QtCore.Qt.LeftDockWidgetArea, self.pointCloudDockWidget)
         widgetno += 1
 

--- a/src/idvc/dvc_interface.py
+++ b/src/idvc/dvc_interface.py
@@ -2175,7 +2175,6 @@ It is used as a global starting point and a translation reference."
 
         mp_widgets['mask_downsampled_coords_warning'] = QLabel(groupBox)
         mp_widgets['mask_downsampled_coords_warning'].setWordWrap(True)
-        mp_widgets['mask_downsampled_coords_warning'].setAutoFillBackground(False)
         mp_widgets['mask_downsampled_coords_warning'].setText("Note: if your image has been downsampled, the number of slices is in the coordinates of the downsampled image.")
         formLayout.setWidget(widgetno, QFormLayout.FieldRole, mp_widgets['mask_downsampled_coords_warning'])
         widgetno += 1

--- a/src/idvc/dvc_interface.py
+++ b/src/idvc/dvc_interface.py
@@ -2181,8 +2181,15 @@ It is used as a global starting point and a translation reference."
         formLayout.setWidget(widgetno, QFormLayout.FieldRole, mp_widgets['mask_extend_below_entry'])
         widgetno += 1
 
-        mp_widgets['mask_downsampled_coords_warning'] = QLabel(groupBox)
-        mp_widgets['mask_downsampled_coords_warning'].setText("Note: if your image has been downsampled, the number of slices is in the coordinates of the downsampled image.")
+        mp_widgets['mask_downsampled_coords_warning'] = QScrollArea()
+        qlabel = QLabel(groupBox)
+        qlabel.setWordWrap(True)
+        mp_widgets['mask_downsampled_coords_warning'].setWidget(qlabel)
+        mp_widgets['mask_downsampled_coords_warning'].setFrameShape(QFrame.NoFrame)
+        mp_widgets['mask_downsampled_coords_warning'].setFrameShadow(QFrame.Plain)
+        mp_widgets['mask_downsampled_coords_warning'].setStyleSheet("border: 0px;")
+        mp_widgets['mask_downsampled_coords_warning'].setWidgetResizable(True)
+        qlabel.setText("Note: if your image has been downsampled, the number of slices is in the coordinates of the downsampled image.")
         formLayout.setWidget(widgetno, QFormLayout.FieldRole, mp_widgets['mask_downsampled_coords_warning'])
         widgetno += 1
 

--- a/src/idvc/utilities.py
+++ b/src/idvc/utilities.py
@@ -83,15 +83,8 @@ def generateUIDockParameters(self, title): #copied from dvc_configurator.py
     dockContentsVerticalLayout = QVBoxLayout(dockWidgetContents)
     dockContentsVerticalLayout.setContentsMargins(0, 0, 0, 0)
 
- 
-
     # Create widget for dock contents
     internalDockWidget = QWidget(dockWidgetContents)
-   
-   #create scroll widget
-    scroll_area = QScrollArea()
-    scroll_area.setWidgetResizable(True)
-    scroll_area.setWidget(internalDockWidget)
 
     # Add vertical layout to dock widget
     internalWidgetVerticalLayout = QVBoxLayout(internalDockWidget)
@@ -107,7 +100,7 @@ def generateUIDockParameters(self, title): #copied from dvc_configurator.py
 
     # Add elements to layout
     internalWidgetVerticalLayout.addWidget(paramsGroupBox)
-    dockContentsVerticalLayout.addWidget(scroll_area)
+    dockContentsVerticalLayout.addWidget(internalDockWidget)
     dockWidget.setWidget(dockWidgetContents)
 
     #        self.graphWidgetVL.addWidget(self.graphParamsGroupBox)

--- a/src/idvc/utilities.py
+++ b/src/idvc/utilities.py
@@ -94,6 +94,7 @@ def generateUIDockParameters(self, title): #copied from dvc_configurator.py
     # Add vertical layout to dock widget
     internalWidgetVerticalLayout = QVBoxLayout(internalDockWidget)
     internalWidgetVerticalLayout.setContentsMargins(0, 0, 0, 0)
+    internalWidgetVerticalLayout.setAlignment(Qt.AlignTop)
 
     # Add group box
     paramsGroupBox = QGroupBox(internalDockWidget)
@@ -101,7 +102,6 @@ def generateUIDockParameters(self, title): #copied from dvc_configurator.py
 
     # Add form layout to group box
     groupBoxFormLayout = QFormLayout(paramsGroupBox)
-    #groupBoxFormLayout.setFormAlignment(Qt.AlignCenter)
 
     # Add elements to layout
     internalWidgetVerticalLayout.addWidget(paramsGroupBox)

--- a/src/idvc/utilities.py
+++ b/src/idvc/utilities.py
@@ -83,13 +83,15 @@ def generateUIDockParameters(self, title): #copied from dvc_configurator.py
     dockContentsVerticalLayout = QVBoxLayout(dockWidgetContents)
     dockContentsVerticalLayout.setContentsMargins(0, 0, 0, 0)
 
-    #create scroll widget
-    scroll_area = QScrollArea()
-    scroll_area.setWidgetResizable(True)
-    scroll_area.setWidget(dockWidgetContents)
+ 
 
     # Create widget for dock contents
     internalDockWidget = QWidget(dockWidgetContents)
+   
+   #create scroll widget
+    scroll_area = QScrollArea()
+    scroll_area.setWidgetResizable(True)
+    scroll_area.setWidget(internalDockWidget)
 
     # Add vertical layout to dock widget
     internalWidgetVerticalLayout = QVBoxLayout(internalDockWidget)
@@ -105,8 +107,8 @@ def generateUIDockParameters(self, title): #copied from dvc_configurator.py
 
     # Add elements to layout
     internalWidgetVerticalLayout.addWidget(paramsGroupBox)
-    dockContentsVerticalLayout.addWidget(internalDockWidget)
-    dockWidget.setWidget(scroll_area)
+    dockContentsVerticalLayout.addWidget(scroll_area)
+    dockWidget.setWidget(dockWidgetContents)
 
     #        self.graphWidgetVL.addWidget(self.graphParamsGroupBox)
     #        self.graphDockVL.addWidget(self.dockWidget)

--- a/src/idvc/utilities.py
+++ b/src/idvc/utilities.py
@@ -83,6 +83,11 @@ def generateUIDockParameters(self, title): #copied from dvc_configurator.py
     dockContentsVerticalLayout = QVBoxLayout(dockWidgetContents)
     dockContentsVerticalLayout.setContentsMargins(0, 0, 0, 0)
 
+    #create scroll widget
+    scroll_area = QScrollArea()
+    scroll_area.setWidgetResizable(True)
+    scroll_area.setWidget(dockWidgetContents)
+
     # Create widget for dock contents
     internalDockWidget = QWidget(dockWidgetContents)
 
@@ -101,7 +106,7 @@ def generateUIDockParameters(self, title): #copied from dvc_configurator.py
     # Add elements to layout
     internalWidgetVerticalLayout.addWidget(paramsGroupBox)
     dockContentsVerticalLayout.addWidget(internalDockWidget)
-    dockWidget.setWidget(dockWidgetContents)
+    dockWidget.setWidget(scroll_area)
 
     #        self.graphWidgetVL.addWidget(self.graphParamsGroupBox)
     #        self.graphDockVL.addWidget(self.dockWidget)


### PR DESCRIPTION
Closes #282

- Make 3D viewer dock widget floatable
- Add minimum height for 3D Viewer
- Add scroll area to point cloud dock widget
- Left the push button in the point cloud transparent. See picture. This bug seems less troublesome than non being able to see/click on buttons.

![point-cloud-tab](https://github.com/TomographicImaging/iDVC/assets/138598662/47e44663-9160-4410-bbc8-cd2227ed9dcf)
