### PR TITLE
Fix vtk version to 8.1.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # ChangeLog
 
 ## vx.x.x
+* Fix vtk version #291
 * Edit DVC-Results tab #231
 * Edit mask/point-cloud/results tooltips, help text and documentation #257 #286 #287
 * Scales the displacement vectors keeping the color bar with the displacement values. Adds title to color bar #270

--- a/recipe/dev_environment.yml
+++ b/recipe/dev_environment.yml
@@ -15,4 +15,4 @@ dependencies:
     - matplotlib
     - openmp                # [osx]
     - qdarkstyle
-    - vtk
+    - vtk = 8.1.2

--- a/recipe/dev_environment.yml
+++ b/recipe/dev_environment.yml
@@ -15,4 +15,4 @@ dependencies:
     - matplotlib
     - openmp                # [osx]
     - qdarkstyle
-    - vtk = 8.1.2
+    - vtk =8.1.2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,7 +45,7 @@ requirements:
     - matplotlib
     - openmp                # [osx]
     - qdarkstyle
-    - vtk
+    - vtk = 8.1.2
 
 about:
   home: http://www.ccpi.ac.uk

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,7 +45,7 @@ requirements:
     - matplotlib
     - openmp                # [osx]
     - qdarkstyle
-    - vtk = 8.1.2
+    - vtk =8.1.2
 
 about:
   home: http://www.ccpi.ac.uk


### PR DESCRIPTION
This is a temporary solution to release the software v24.0.0 for the workshop in June 2024. After the workshop we can work properly fix the problem with vtk 9 as described in #280 