### PR TITLE
Add nexus reader

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,8 @@
 
 ## v25.0.0
 Enhancements:
-* Adds nexus ".nxs" files reader #387
+* Add nexus ".nxs" files reader #387
+* Add warning for casting of nagative values in nxs and TIFF #387
 * Update the viewer when the "view" dropdown in the results tab changes #403
 * Update default values in "Run DVC" tab #402
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## v25.0.0
 Enhancements:
-* Add nexus ".nxs" files reader #387
+* Add nexus ".nxs" files reader and converter into raw for the dvc_runner #387
 * Removes raw (temporary) files created from nxs and TIFF from the session folder #387
 * Connect error dialog to run_dvc worker #387
 * Add warning for casting of nagative values in nxs and TIFF #387

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # ChangeLog
 
-## vx.x.x
+## v25.0.0
 
 Enhancements:
 - Adds nexus ".nxs" files reader #387

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 Enhancements:
 * Add nexus ".nxs" files reader #387
 * Removes raw (temporary) files created from nxs and TIFF from the session folder #387
+* Connect error dialog to run_dvc worker #387
 * Add warning for casting of nagative values in nxs and TIFF #387
 * Update the viewer when the "view" dropdown in the results tab changes #403
 * Update default values in "Run DVC" tab #402

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # ChangeLog
 
+## vx.x.x
+
+Enhancements:
+- Adds nexus ".nxs" files reader #387
+
 ## v24.1.1
 Bug fixes:
 * Fix abscissa order in graphs #372

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,11 @@
 # ChangeLog
 
 ## v25.0.0
-
 Enhancements:
 - Adds nexus ".nxs" files reader #387
+
+Dependencies:
+* Add pyside2 and upgrade viewer version #387
 
 ## v24.1.1
 Bug fixes:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Enhancements:
 * Update default values in "Run DVC" tab #402
 
 Bug fixes:
+* Add casting of int8 and int16 in TIFF conversion to raw #387
 * Edit the way `vol_bit_depth` is defined in TIFF reader #387
 * Fix statistical analysis graphs for 1 data point #419
 * Add scrollbar to docked widgets #405

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 # ChangeLog
 
 ## v25.0.0
+Bug fixes:
+* Edit the way `vol_bit_depth` is defined in TIFF reader #387
+
 Enhancements:
 - Adds nexus ".nxs" files reader #387
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@ Enhancements:
 * Improve `ImageDataCreator` #387
 * Removes raw (temporary) files created from nxs and TIFF from the session folder #387
 * Connect error dialog to run_dvc worker #387
-* Add warning for casting of nagative values in nxs and TIFF #387
+* Add warning for casting of negative values in nxs and TIFF #387
 * Update the viewer when the "view" dropdown in the results tab changes #403
 * Update default values in "Run DVC" tab #402
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## v25.0.0
 Enhancements:
 * Add nexus ".nxs" files reader and converter into raw for the dvc_runner #387
+* Improve `ImageDataCreator` #387
 * Removes raw (temporary) files created from nxs and TIFF from the session folder #387
 * Connect error dialog to run_dvc worker #387
 * Add warning for casting of nagative values in nxs and TIFF #387

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## v25.0.0
 Enhancements:
 * Add nexus ".nxs" files reader #387
+* Removes raw (temporary) files created from nxs and TIFF from the session folder #387
 * Add warning for casting of nagative values in nxs and TIFF #387
 * Update the viewer when the "view" dropdown in the results tab changes #403
 * Update default values in "Run DVC" tab #402

--- a/recipe/dev_environment.yml
+++ b/recipe/dev_environment.yml
@@ -9,7 +9,7 @@ dependencies:
     - numpy
     - pandas
     - scipy
-    - ccpi::ccpi-viewer >=24.1.0
+    - ccpi::ccpi-viewer >24.1.0
     - ccpi::ccpi-dvc >=22.0.0
     - natsort
     - docopt

--- a/recipe/dev_environment.yml
+++ b/recipe/dev_environment.yml
@@ -8,8 +8,9 @@ dependencies:
     - python
     - numpy
     - pandas
+    - pyside2
     - scipy
-    - ccpi::ccpi-viewer >24.1.0
+    - ccpi::ccpi-viewer >=25.0.0
     - ccpi::ccpi-dvc >=22.0.0
     - natsort
     - docopt

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,7 @@ requirements:
     - numpy
     - pandas
     - scipy
-    - ccpi-viewer >=24.1.0
+    - ccpi-viewer >24.1.0
     - ccpi-dvc >=22.0.0
     - natsort
     - docopt

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,8 +39,9 @@ requirements:
     - python
     - numpy
     - pandas
+    - pyside2
     - scipy
-    - ccpi-viewer >24.1.0
+    - ccpi-viewer >=25.0.0
     - ccpi-dvc >=22.0.0
     - natsort
     - docopt

--- a/src/idvc/dvc_interface.py
+++ b/src/idvc/dvc_interface.py
@@ -5156,6 +5156,8 @@ The dimensionality of the pointcloud can also be changed in the Point Cloud pane
         self.SaveWindow.close()
 
     def SaveSession(self, text_value, compress, event):
+        """Saves a software session. If raw files are created from nxs or TIFF input files"
+        they are removed from the session folder."""
         # Save window geometry and state of dockwindows
         # https://doc.qt.io/qt-5/qwidget.html#saveGeometry
         g = self.saveGeometry()
@@ -5300,7 +5302,6 @@ The dimensionality of the pointcloud can also be changed in the Point Cloud pane
         raw_reference_file_fname = os.path.join(results_folder, 'reference.raw')
         raw_correlate_file_fname = os.path.join(results_folder, 'correlate.raw')
                 
-        # Remove files if they exist
         for file_path in [raw_reference_file_fname, raw_correlate_file_fname]:
             if os.path.exists(file_path):
                 os.remove(file_path)

--- a/src/idvc/dvc_interface.py
+++ b/src/idvc/dvc_interface.py
@@ -441,7 +441,7 @@ class MainWindow(QMainWindow):
         formLayout = help_panel[6]
         self.help_dock = dockWidget
 
-        self.help_text = ["Please use 'mha', 'mhd', npy', 'raw' or 'TIFF' images.\n"
+        self.help_text = ["Please use 'hdf5', 'mha', 'mhd', npy', 'nxs', 'raw' or 'TIFF' images.\n"
         "You can view the shortcuts for the viewer by clicking on the 2D image and then pressing the 'h' key."]
 
         self.help_text.append(

--- a/src/idvc/dvc_interface.py
+++ b/src/idvc/dvc_interface.py
@@ -4774,6 +4774,7 @@ This parameter has a strong effect on computation time, so be careful."
             #TODO: test this and see if we need to stop the worker, or if not returning anything is enough
 
     def run_external_code(self, error = None):
+        "The error signal of the setup worker is connected to a dialog."
         if error == "subvolume error":
             self.progress_window.setValue(100)
             self.warningDialog("Minimum number of sampling points in subvolume value higher than maximum", window_title="Value Error")
@@ -4807,6 +4808,9 @@ The dimensionality of the pointcloud can also be changed in the Point Cloud pane
         setup.signals.progress.connect(self.progress)
         # should connect also the error message
         setup.signals.finished.connect(self.dvc_runner.run_dvc)
+        # connect error signal to an ErrorDialog
+        ff = partial(displayErrorDialogFromWorker, self)
+        setup.signals.error.connect(ff)
         self.threadpool.start(setup)
         # self.dvc_runner.run_dvc()
 

--- a/src/idvc/dvc_interface.py
+++ b/src/idvc/dvc_interface.py
@@ -772,6 +772,8 @@ class MainWindow(QMainWindow):
         msg.exec_()
 
     def view_image(self):
+        """Called when the view image button is clicked in the first tab, or
+        when a session is loaded."""
         self.ref_image_data = vtk.vtkImageData()
         self.image_info = dict()
         if self.settings.value("gpu_size") is not None and self.settings.value("volume_mapper") == "gpu":
@@ -788,9 +790,9 @@ class MainWindow(QMainWindow):
             else:
                 target_size = 0.125
         self.target_image_size = target_size
-        
-        ImageDataCreator.createImageData(self, self.image[0], self.ref_image_data, info_var = self.image_info, convert_raw = True,  
-        finish_fn = partial(self.save_image_info, "ref"), resample= True, target_size = target_size, output_dir='.')
+        image_data_creator = ImageDataCreator(self, self.image[0], self.ref_image_data, info_var = self.image_info, resample= True, target_size = target_size)
+        image_data_creator.createImageData(convert_raw = True,  
+        finish_fn = partial(self.save_image_info, "ref"), output_dir='.')
 
     def save_image_info(self, image_type):
         """Sets the value of the registration box size to the 1/10 of the max dimension."""
@@ -849,7 +851,8 @@ class MainWindow(QMainWindow):
                 self.dvc_input_image[0] = image_file
                 if os.path.splitext(self.image[0][0])[1] in ['.mhd', '.mha']: #need to call create image data so we read header and save image to file w/o header
                     self.temp_image_data = vtk.vtkImageData()
-                    ImageDataCreator.createImageData(self, self.image[1], self.temp_image_data, info_var=self.image_info, convert_raw=True,  finish_fn=partial(
+                    image_data_creator = ImageDataCreator(self, self.image[1], self.temp_image_data, info_var=self.image_info) 
+                    image_data_creator.createImageData(convert_raw=True,  finish_fn=partial(
                         self.save_image_info, "corr"), output_dir='.')
             elif image_type == "corr":
                 self.dvc_input_image[1] = image_file
@@ -1784,14 +1787,16 @@ It is used as a global starting point and a translation reference."
             if not (hasattr(self, 'unsampled_ref_image_data') and hasattr(self, 'unsampled_corr_image_data')):
                 #print("About to create image")
                 self.unsampled_ref_image_data = vtk.vtkImageData()
-                ImageDataCreator.createImageData(self, self.image[0], self.unsampled_ref_image_data, info_var=self.unsampled_image_info, crop_image=True, origin=origin,
-                                                 target_z_extent=target_z_extent, output_dir=os.path.abspath(tempfile.tempdir), finish_fn=self.LoadCorrImageForReg, crop_corr_image=True)
+                image_data_creator = ImageDataCreator(self, self.image[0], self.unsampled_ref_image_data, info_var=self.unsampled_image_info, crop_image=True, origin=origin,
+                                                 target_z_extent=target_z_extent)
+                image_data_creator.createImageData(output_dir=os.path.abspath(tempfile.tempdir), finish_fn=self.LoadCorrImageForReg, crop_corr_image=True)
                 #TODO: move to doing both image data creators simultaneously - would this work?
                 return
 
             if previous_reg_box_extent != reg_box_extent: # If registration box is changed need to update the cropped images.
-                ImageDataCreator.createImageData(self, self.image[0], self.unsampled_ref_image_data, info_var=self.unsampled_image_info, crop_image=True, origin=origin,
-                                                 target_z_extent=target_z_extent, output_dir=os.path.abspath(tempfile.tempdir), finish_fn=self.LoadCorrImageForReg, crop_corr_image=True)
+                image_data_creator = ImageDataCreator(self, self.image[0], self.unsampled_ref_image_data, info_var=self.unsampled_image_info, crop_image=True, origin=origin,
+                                                 target_z_extent=target_z_extent)
+                image_data_creator.createImageData(output_dir=os.path.abspath(tempfile.tempdir), finish_fn=self.LoadCorrImageForReg, crop_corr_image=True)
             else:
                 self.completeRegistration()
             
@@ -1836,8 +1841,8 @@ It is used as a global starting point and a translation reference."
         z_extent = self.target_cropped_image_z_extent
 
         self.unsampled_corr_image_data = vtk.vtkImageData()
-        ImageDataCreator.createImageData(self, self.image[1], self.unsampled_corr_image_data, info_var=self.unsampled_image_info, resample=resample_corr_image,
-                                         crop_image=crop_corr_image, origin=origin, target_z_extent=z_extent, finish_fn=self.completeRegistration, output_dir=os.path.abspath(tempfile.tempdir))
+        image_data_creator = ImageDataCreator(self, self.image[1], self.unsampled_corr_image_data, info_var=self.unsampled_image_info, resample=resample_corr_image, crop_image=crop_corr_image, origin=origin, target_z_extent=z_extent)
+        image_data_creator.createImageData(finish_fn=self.completeRegistration, output_dir=os.path.abspath(tempfile.tempdir))
 
     def completeRegistration(self):
         """It shows the registration difference volume in the viewer and sets up the tab for the registration. 

--- a/src/idvc/dvc_interface.py
+++ b/src/idvc/dvc_interface.py
@@ -5288,7 +5288,14 @@ The dimensionality of the pointcloud can also be changed in the Point Cloud pane
         os.close(fd)
 
         self.create_progress_window("Saving","Saving")
-  
+        results_folder = os.path.join(tempfile.tempdir, "Results")
+        raw_reference_file_fname = os.path.join(results_folder, 'reference.raw')
+        raw_correlate_file_fname = os.path.join(results_folder, 'correlate.raw')
+                
+        # Remove files if they exist
+        for file_path in [raw_reference_file_fname, raw_correlate_file_fname]:
+            if os.path.exists(file_path):
+                os.remove(file_path)
         zip_worker = Worker(self.ZipDirectory, tempfile.tempdir, compress)
         if type(event) == QCloseEvent:
             zip_worker.signals.finished.connect(lambda: self.RemoveTemp(event))

--- a/src/idvc/dvc_runner.py
+++ b/src/idvc/dvc_runner.py
@@ -237,7 +237,6 @@ class DVC_runner(object):
         - rigid_trans: rigid translation between the reference and correlation volumes
         - point0_world_coordinate: world coordinates of the starting point for the DVC analysis
         '''
-
         self.processes = []
         self.process_num = 0
         message_callback = kwargs.get('message_callback', PrintCallback())
@@ -259,31 +258,41 @@ class DVC_runner(object):
         progress_callback.emit(10)
         # Convert to raw if files are a list of tiffs
         if isinstance(reference_file, (list, tuple)):
-            message_callback.emit("Converting reference file to raw format")
             base = os.path.abspath(self.session_folder)
-            raw_reference_file_fname = os.path.join(base, config['run_folder'], 'reference.raw')
-            save_tiff_stack_as_raw(reference_file, raw_reference_file_fname, progress_callback, 10, 50)
+            results_folder = os.path.dirname(os.path.join(base, config['run_folder']))
+            raw_reference_file_fname = os.path.join(results_folder, 'reference.raw')
+            if not os.path.exists(raw_reference_file_fname):
+                message_callback.emit("Converting reference file to raw format")
+                save_tiff_stack_as_raw(reference_file, raw_reference_file_fname, progress_callback, 10, 50)
             reference_file = raw_reference_file_fname
         elif reference_file.endswith(('.nxs', '.h5', '.hdf5')):
-            message_callback.emit("Converting reference file to raw format")
             base = os.path.abspath(self.session_folder)
-            raw_reference_file_fname = os.path.join(base, config['run_folder'], 'reference.raw')
-            save_nxs_as_raw(reference_file, self.main_window.hdf5_dataset_path, raw_reference_file_fname)
+            results_folder = os.path.dirname(os.path.join(base, config['run_folder']))
+            raw_reference_file_fname = os.path.join(results_folder, 'reference.raw')
+            if not os.path.exists(raw_reference_file_fname):
+                message_callback.emit("Converting reference file to raw format")
+                save_nxs_as_raw(reference_file, self.main_window.hdf5_dataset_path, raw_reference_file_fname)
             reference_file = raw_reference_file_fname
         progress_callback.emit(50)
 
         if isinstance(correlate_file, (list, tuple)):
-            message_callback.emit("Converting correlate file to raw format")
             base = os.path.abspath(self.session_folder)
-            raw_correlate_file_fname = os.path.join(base, config['run_folder'], 'correlate.raw')
-            save_tiff_stack_as_raw(correlate_file, raw_correlate_file_fname, progress_callback, 50, 90)
+            results_folder = os.path.dirname(os.path.join(base, config['run_folder']))
+            raw_correlate_file_fname = os.path.join(results_folder, 'correlate.raw')
+            if not os.path.exists(raw_correlate_file_fname):
+                message_callback.emit("Converting correlate file to raw format")
+                save_tiff_stack_as_raw(correlate_file, raw_correlate_file_fname, progress_callback, 50, 90)
             correlate_file = raw_correlate_file_fname
+
         elif correlate_file.endswith(('.nxs', '.h5', '.hdf5')):
-            message_callback.emit("Converting correlate file to raw format")
             base = os.path.abspath(self.session_folder)
-            raw_correlate_file_fname = os.path.join(base, config['run_folder'], 'correlate.raw')
-            save_nxs_as_raw(correlate_file, self.main_window.hdf5_dataset_path, raw_correlate_file_fname)
+            results_folder = os.path.dirname(os.path.join(base, config['run_folder']))
+            raw_correlate_file_fname = os.path.join(results_folder, 'correlate.raw')
+            if not os.path.exists(raw_correlate_file_fname):
+                message_callback.emit("Converting correlate file to raw format")
+                save_nxs_as_raw(correlate_file, self.main_window.hdf5_dataset_path, raw_correlate_file_fname)
             correlate_file = raw_correlate_file_fname
+
         progress_callback.emit(90)
 
         message_callback.emit("Creating run configurations")
@@ -341,7 +350,6 @@ class DVC_runner(object):
                 for i, l in enumerate(f):
                     pass
             i+=1
-            #print(i)
             if i < points:
                 total_points += i
             else:

--- a/src/idvc/dvc_runner.py
+++ b/src/idvc/dvc_runner.py
@@ -22,7 +22,7 @@ import json
 import time
 import shutil
 import platform
-from .io import save_tiff_stack_as_raw
+from .io import save_tiff_stack_as_raw, save_nxs_as_raw
 
 class PrintCallback(object):
     '''Class to handle the emit call when no callback is provided'''
@@ -264,6 +264,12 @@ class DVC_runner(object):
             raw_reference_file_fname = os.path.join(base, config['run_folder'], 'reference.raw')
             save_tiff_stack_as_raw(reference_file, raw_reference_file_fname, progress_callback, 10, 50)
             reference_file = raw_reference_file_fname
+        elif reference_file.endswith(('.nxs', '.h5', '.hdf5')):
+            message_callback.emit("Converting reference file to raw format")
+            base = os.path.abspath(self.session_folder)
+            raw_reference_file_fname = os.path.join(base, config['run_folder'], 'reference.raw')
+            save_nxs_as_raw(reference_file, self.main_window.hdf5_dataset_path, raw_reference_file_fname)
+            reference_file = raw_reference_file_fname
         progress_callback.emit(50)
 
         if isinstance(correlate_file, (list, tuple)):
@@ -271,6 +277,12 @@ class DVC_runner(object):
             base = os.path.abspath(self.session_folder)
             raw_correlate_file_fname = os.path.join(base, config['run_folder'], 'correlate.raw')
             save_tiff_stack_as_raw(correlate_file, raw_correlate_file_fname, progress_callback, 50, 90)
+            correlate_file = raw_correlate_file_fname
+        elif correlate_file.endswith(('.nxs', '.h5', '.hdf5')):
+            message_callback.emit("Converting correlate file to raw format")
+            base = os.path.abspath(self.session_folder)
+            raw_correlate_file_fname = os.path.join(base, config['run_folder'], 'correlate.raw')
+            save_nxs_as_raw(correlate_file, self.main_window.hdf5_dataset_path, raw_correlate_file_fname)
             correlate_file = raw_correlate_file_fname
         progress_callback.emit(90)
 

--- a/src/idvc/io.py
+++ b/src/idvc/io.py
@@ -1206,7 +1206,7 @@ def save_tiff_stack_as_raw(filenames: list, output_fname: str, progress_callback
             reader.SetFileName(el)
             reader.Update()
             slice_data = Converter.vtk2numpy(reader.GetOutput())
-            if slice_data.dtype not in [numpy.uint8, numpy.uint16, numpy.int8, numpy.int16]:
+            if slice_data.dtype not in [numpy.uint8, numpy.uint16]:
                 # scale to uint16
                 convert_to_dtype = numpy.uint16
                 # rescale as float32

--- a/src/idvc/io.py
+++ b/src/idvc/io.py
@@ -601,7 +601,7 @@ def loadTif(*args, **kwargs):
 
 def loadNxs(*args, **kwargs):
     """
-    Loads a NeXus (.nxs) file and processes its dataset into a raw image format.
+    Loads a NeXus (.nxs) file and processes its dataset into a vtkImageData.
 
     Parameters:
     -----------

--- a/src/idvc/io.py
+++ b/src/idvc/io.py
@@ -613,6 +613,11 @@ def loadNpyImage(**kwargs):
         else:
             vol_bit_depth = None  # in this case we can't run the DVC code
             output_image = None
+            if numpy.issubdtype(numpy_array.dtype , numpy.signedinteger) or numpy.issubdtype(numpy_array.dtype , numpy.floating):
+                warnings.warn(
+                f"Cast data of type {numpy_array.dtype} to uint8 or uint16 before proceeding.",
+                RuntimeWarning
+                )
             return
 
         if image_info is not None:

--- a/src/idvc/io.py
+++ b/src/idvc/io.py
@@ -191,7 +191,7 @@ class ImageDataCreator(object):
                 main_window, message=error_text, title=error_title, 
                 detailed_message='File format is not supported. Accepted formats include: .hdf5, .mhd, .mha, .npy, .nxs, .tif, .raw')
             return
-
+    
         main_window.progress_window.setValue(10)
 
         # connect signals and slots
@@ -208,6 +208,7 @@ class ImageDataCreator(object):
         
         main_window.threadpool = QThreadPool()
         main_window.threadpool.start(image_worker)
+
 
     def HDF5InputDialog_onOk_redefined(self, dialog):
         dialog.getHDF5Attributes()
@@ -1220,7 +1221,7 @@ def save_tiff_stack_as_raw(filenames: list, output_fname: str, progress_callback
 def save_nxs_as_raw(nexus_file, dataset_path, raw_file):
     """
     Converts a NeXus (.nxs) file to a raw binary file using the dataset path stored in 'dataset_path'.
-    If the dataset is not uint8 or uint16, it will be scaled to uint16. Negative values are clipped to zero.
+    If the dataset is not uint8 or uint16, it will be scaled to uint16.
 
     Parameters:
     -----------
@@ -1243,9 +1244,6 @@ def save_nxs_as_raw(nexus_file, dataset_path, raw_file):
             return
         
         else:
-            if numpy.issubdtype(original_dtype, numpy.signedinteger) or numpy.issubdtype(original_dtype, numpy.floating):
-                print("Clipping data negative values to zero.")
-                data = numpy.clip(data, 0, None)
             for i in range(data.shape[0]):
                 slice_data = data[i:i+1]
                 if i == 0:

--- a/src/idvc/io.py
+++ b/src/idvc/io.py
@@ -236,8 +236,6 @@ class ImageDataCreator(object):
         **kwargs : dict
             - progress_callback (callable, optional): Function to emit progress updates
         """
-        print("load nxs")
-        print(self.target_z_extent)
         image_info = self.info_var
         progress_callback = kwargs.get('progress_callback')
 

--- a/src/idvc/io.py
+++ b/src/idvc/io.py
@@ -502,10 +502,25 @@ def loadNpyImage(**kwargs):
     return 0
 
 def loadTif(*args, **kwargs):
-    # filenames, reader, output_image,   convert_numpy = False,  image_info = None, progress_callback=None):
-    # filenames, reader, output_image,   convert_numpy = False,  image_info = None, progress_callback=None
-    # var,resample=resample, target_size=target_size,
-    # origin=origin, target_z_extent=target_z_extent
+    """
+    Loads tiff (.tiff) file/s and processes its/their dataset into a raw image format.
+
+    Parameters:
+    -----------
+    *args : tuple
+        - filenames (str): Path to the tiff (.tiff) files.
+        - output_image (vtkImageData): The VTK image object where the output will be stored.
+
+    **kwargs : dict
+        - dataset_path (str, required): The internal HDF5 path to the dataset inside the .nxs file.
+        - image_info (dict, optional): A dictionary to store metadata about the image.
+        - progress_callback (callable, optional): Function to emit progress updates.
+        - resample (bool, default=False): Whether to resample the dataset.
+        - crop_image (bool, default=False): Whether to crop the dataset.
+        - target_size (float, default=0.125): Target size for resampling (in GB).
+        - origin (tuple, default=(0, 0, 0)): The origin coordinates for cropping.
+        - target_z_extent (tuple, default=(0, 0)): The Z extent for cropping.
+    """
     filenames, output_image = args
     image_info = kwargs.get('image_info', None)
     progress_callback = kwargs.get('progress_callback')
@@ -514,6 +529,7 @@ def loadTif(*args, **kwargs):
     target_size = kwargs.get('target_size', 0.125)
     origin = kwargs.get('origin', (0, 0, 0))
     target_z_extent = kwargs.get('target_z_extent', (0, 0))
+
     bits_per_byte = 16
 
     # time.sleep(0.1) #required so that progress window displays
@@ -584,6 +600,25 @@ def loadTif(*args, **kwargs):
     return 0
 
 def loadNxs(*args, **kwargs):
+    """
+    Loads a NeXus (.nxs) file and processes its dataset into a raw image format.
+
+    Parameters:
+    -----------
+    *args : tuple
+        - filenames (str): Path to the NeXus (.nxs) file.
+        - output_image (vtkImageData): The VTK image object where the output will be stored.
+
+    **kwargs : dict
+        - dataset_path (str, required): The internal HDF5 path to the dataset inside the .nxs file.
+        - image_info (dict, optional): A dictionary to store metadata about the image.
+        - progress_callback (callable, optional): Function to emit progress updates.
+        - resample (bool, default=False): Whether to resample the dataset.
+        - crop_image (bool, default=False): Whether to crop the dataset.
+        - target_size (float, default=0.125): Target size for resampling (in GB).
+        - origin (tuple, default=(0, 0, 0)): The origin coordinates for cropping.
+        - target_z_extent (tuple, default=(0, 0)): The Z extent for cropping.
+    """
     filenames, output_image = args
     image_info = kwargs.get('image_info', None)
     progress_callback = kwargs.get('progress_callback')

--- a/src/idvc/io.py
+++ b/src/idvc/io.py
@@ -599,18 +599,19 @@ def loadTif(*args, **kwargs):
     # all good, return 0
     return 0
 
-def loadNxs(*args, **kwargs):
+def loadNxs(filenames, output_image, dataset_path, **kwargs):
     """
     Loads a NeXus (.nxs) file and processes its dataset into a vtkImageData.
 
     Parameters:
     -----------
-    *args : tuple
-        - filenames (str): Path to the NeXus (.nxs) file.
-        - output_image (vtkImageData): The VTK image object where the output will be stored.
-
+    filenames : str
+        Path to the NeXus (.nxs) file.
+    output_image : vtkImageData
+        The VTK image object where the output will be stored.
+    dataset_path : str
+        The internal HDF5 path to the dataset inside the .nxs file.
     **kwargs : dict
-        - dataset_path (str, required): The internal HDF5 path to the dataset inside the .nxs file.
         - image_info (dict, optional): A dictionary to store metadata about the image.
         - progress_callback (callable, optional): Function to emit progress updates.
         - resample (bool, default=False): Whether to resample the dataset.
@@ -619,10 +620,8 @@ def loadNxs(*args, **kwargs):
         - origin (tuple, default=(0, 0, 0)): The origin coordinates for cropping.
         - target_z_extent (tuple, default=(0, 0)): The Z extent for cropping.
     """
-    filenames, output_image = args
     image_info = kwargs.get('image_info', None)
     progress_callback = kwargs.get('progress_callback')
-    dataset_path = kwargs.get('dataset_path', None)  # Path inside .nxs file
     resample = kwargs.get('resample', False)
     crop_image = kwargs.get('crop_image', False)
     target_size = kwargs.get('target_size', 0.125)
@@ -681,8 +680,11 @@ def loadNxs(*args, **kwargs):
                 image_info['sampled'] = False
                 image_info['cropped'] = True
 
+        else:
+            raise ValueError(f"Resampling or cropping must be performed when loading an image.")
+    
         vol_bit_depth = data.dtype.itemsize * bits_per_byte
-
+        
         if image_info is not None:
             image_info["vol_bit_depth"] = vol_bit_depth
             image_info["shape"] = shape

--- a/src/idvc/io.py
+++ b/src/idvc/io.py
@@ -731,7 +731,7 @@ def loadTif(*args, **kwargs):
     elif image_data.dtype in ["int16", "uint16", "int32", "uint32", "float32", "float64"]:
         vol_bit_depth = 16
 
-    if (numpy.issubdtype(image_data.dtype , numpy.signedinteger) or numpy.issubdtype(image_data.dtype , numpy.floating)) and numpy.any(data < 0):
+    if (numpy.issubdtype(image_data.dtype , numpy.signedinteger) or numpy.issubdtype(image_data.dtype , numpy.floating)) and numpy.any(image_data < 0):
         warnings.warn(
         f"Data of type {image_data.dtype} contains negative values. "
         f"Negative values will be reinterpreted as positive values when cast to uint16.",

--- a/src/idvc/io.py
+++ b/src/idvc/io.py
@@ -733,13 +733,11 @@ def loadTif(*args, **kwargs):
         image_info['sampled'] = False
 
     dtype = reader.GetOutputVTKType()
-    print(dtype)
 
     if dtype in [vtk.VTK_CHAR, vtk.VTK_UNSIGNED_CHAR]:
         vol_bit_depth = 8
     elif dtype in [vtk.VTK_SHORT, vtk.VTK_UNSIGNED_SHORT, vtk.VTK_INT, vtk.VTK_UNSIGNED_INT,vtk.VTK_FLOAT, vtk.VTK_DOUBLE]:
         vol_bit_depth = 16
-    print(vol_bit_depth)
         
     if dtype in [vtk.VTK_CHAR, vtk.VTK_SHORT, vtk.VTK_INT] or dtype in [vtk.VTK_FLOAT, vtk.VTK_DOUBLE]:
         warnings.warn(

--- a/src/idvc/io.py
+++ b/src/idvc/io.py
@@ -566,7 +566,6 @@ def loadNpyImage(**kwargs):
             else:
                 image_info['sampled'] = True
         # print("Header", header_length)
-        # print("vol_bit_depth", vol_bit_depth)
 
     elif crop_image:
         reader = cilNumpyCroppedReader()

--- a/src/idvc/io.py
+++ b/src/idvc/io.py
@@ -76,7 +76,10 @@ class ImageDataCreator(object):
         '''
 
     def createImageData(main_window, image_files, output_image, *finish_fn_args, info_var=None, convert_numpy=False, convert_raw=True,  resample=False, target_size=0.125, crop_image=False, origin=(0, 0, 0), target_z_extent=(0, 0), output_dir=None, finish_fn=None,  **finish_fn_kwargs):
-        # print("Create image data")
+        """
+        Reads the extention of the image file/s. Can read '.mha', '.mhd', '.npy','tif', 'tiff', '.tif', '.tiff',
+        '.nxs', '.h5', '.hdf5', '.raw'.
+        """
         if len(image_files) == 1:
             image = image_files[0]
             file_extension = os.path.splitext(image)[1]
@@ -120,7 +123,6 @@ class ImageDataCreator(object):
             if dialog.hdf5_attrs == {}:
                 return
             hdf5_dataset_path = dialog.hdf5_attrs['dataset_name'] 
-            print(hdf5_dataset_path)
             with h5py.File(image, "r") as f:
                 if hdf5_dataset_path not in f:
                     raise ValueError(f"Dataset '{hdf5_dataset_path}' not found in the image file.") 
@@ -148,7 +150,7 @@ class ImageDataCreator(object):
                 filename=image)
             displayFileErrorDialog(
                 main_window, message=error_text, title=error_title, 
-                detailed_message='File format is not supported. Accepted formats include: .mhd, .mha, .npy, .tif, .raw')
+                detailed_message='File format is not supported. Accepted formats include: .hdf5, .mhd, .mha, .npy, .nxs, .tif, .raw')
             return
 
         main_window.progress_window.setValue(10)

--- a/src/idvc/io.py
+++ b/src/idvc/io.py
@@ -503,7 +503,7 @@ def loadNpyImage(**kwargs):
 
 def loadTif(*args, **kwargs):
     """
-    Loads tiff (.tiff) file/s and processes its/their dataset into a raw image format.
+    Loads tiff (.tiff) file/s and processes its/their dataset into a vtkImageData.
 
     Parameters:
     -----------

--- a/src/idvc/io.py
+++ b/src/idvc/io.py
@@ -43,6 +43,7 @@ from PySide2.QtWidgets import (QComboBox, QDialog, QDialogButtonBox,
                                QMessageBox, QProgressDialog, QVBoxLayout,
                                QWidget)
 import logging
+import warnings
 
 logger = logging.getLogger(__name__)
 # ImageCreator class
@@ -300,6 +301,13 @@ class ImageDataCreator(object):
             elif data.dtype in ["int16", "uint16", "int32", "uint32", "float32", "float64"]:
                 vol_bit_depth = 16
             
+            if (numpy.issubdtype(data.dtype , numpy.signedinteger) or numpy.issubdtype(data.dtype , numpy.floating)) and numpy.any(data < 0):
+                warnings.warn(
+                f"Data of type {data.dtype} contains negative values. "
+                f"Negative values will be reinterpreted as positive values when cast to uint16.",
+                RuntimeWarning
+                )
+         
             if image_info is not None:
                 image_info["vol_bit_depth"] = vol_bit_depth
                 image_info["shape"] = shape
@@ -723,6 +731,13 @@ def loadTif(*args, **kwargs):
     elif image_data.dtype in ["int16", "uint16", "int32", "uint32", "float32", "float64"]:
         vol_bit_depth = 16
 
+    if (numpy.issubdtype(image_data.dtype , numpy.signedinteger) or numpy.issubdtype(image_data.dtype , numpy.floating)) and numpy.any(data < 0):
+        warnings.warn(
+        f"Data of type {image_data.dtype} contains negative values. "
+        f"Negative values will be reinterpreted as positive values when cast to uint16.",
+        RuntimeWarning
+        )
+                
     if image_info is not None:
         image_info["vol_bit_depth"] = vol_bit_depth
         image_info["shape"] = shape

--- a/src/idvc/io.py
+++ b/src/idvc/io.py
@@ -212,6 +212,10 @@ class ImageDataCreator(object):
 
 
     def HDF5InputDialog_onOk_redefined(self, dialog):
+        """
+        Redefines the ok button in the HDF5 input dialog. It returns if the file has been read before.
+        Else, it stores the dataset path as an attribute and starts the worker.
+        """
         dialog.getHDF5Attributes()
         if dialog.hdf5_attrs == {}:
             return
@@ -224,6 +228,7 @@ class ImageDataCreator(object):
         self.createProgressWindowAndNxsWorker()
         
     def createProgressWindowAndNxsWorker(self):
+        """Creates a progress window and starts the worker to load the nexus file."""
         createProgressWindow(self.main_window, "Converting", "Converting Image")
         self.image_worker = Worker(self.loadNxs, dataset_path = self.main_window.hdf5_dataset_path)
 
@@ -261,9 +266,6 @@ class ImageDataCreator(object):
                     getProgress, progress_callback=progress_callback))
                 reader.Update()
                 self.output_image.ShallowCopy(reader.GetOutput())
-
-                header_length = reader.GetFileHeaderLength()
-                print("Length of header: ", header_length)
 
                 if image_info is not None:
                     image_info['isBigEndian'] = reader.GetBigEndian()
@@ -574,7 +576,6 @@ def loadNpyImage(**kwargs):
                 image_info['sampled'] = False
             else:
                 image_info['sampled'] = True
-        # print("Header", header_length)
 
     elif crop_image:
         reader = cilNumpyCroppedReader()

--- a/src/idvc/io.py
+++ b/src/idvc/io.py
@@ -77,8 +77,10 @@ class ImageDataCreator(object):
 
     def createImageData(main_window, image_files, output_image, *finish_fn_args, info_var=None, convert_numpy=False, convert_raw=True,  resample=False, target_size=0.125, crop_image=False, origin=(0, 0, 0), target_z_extent=(0, 0), output_dir=None, finish_fn=None,  **finish_fn_kwargs):
         """
-        Reads the extention of the image file/s. Can read '.mha', '.mhd', '.npy','tif', 'tiff', '.tif', '.tiff',
-        '.nxs', '.h5', '.hdf5', '.raw'.
+        Reads the extention of the image file/s. Can read '.mha', '.mhd', '.npy','tiff',
+        '.nxs', '.raw'. Opens dialogs for hdf5 and raw formats. 
+        Creates a progress window. Calls the worker to resample or crop the image and convert it into raw. 
+        Note: 'raw' is the specified file format by the dvc core code. 
         """
         if len(image_files) == 1:
             image = image_files[0]

--- a/src/idvc/io.py
+++ b/src/idvc/io.py
@@ -129,9 +129,8 @@ class ImageDataCreator(object):
                 if hdf5_dataset_path not in f:
                     raise ValueError(f"Dataset '{hdf5_dataset_path}' not found in the image file.") 
             createProgressWindow(main_window, "Converting", "Converting Image")
-            image_worker = Worker(loadNxs, image, output_image, dataset_path = hdf5_dataset_path, convert_numpy=convert_numpy, 
-                                 image_info=info_var, resample=resample, crop_image=crop_image, target_size=target_size,
-                                 origin=origin, target_z_extent=target_z_extent)
+            image_worker = Worker(loadNxs, image, output_image, dataset_path = hdf5_dataset_path, resample=resample, crop_image=crop_image, convert_numpy=convert_numpy, 
+                                 image_info=info_var, target_size=target_size, origin=origin, target_z_extent=target_z_extent)
 
         elif file_extension in ['.raw']:
             if 'file_type' in info_var and info_var['file_type'] == 'raw':
@@ -599,7 +598,7 @@ def loadTif(*args, **kwargs):
     # all good, return 0
     return 0
 
-def loadNxs(filenames, output_image, dataset_path, **kwargs):
+def loadNxs(filenames, output_image, dataset_path, resample =  False, crop_image = False, **kwargs):
     """
     Loads a NeXus (.nxs) file and processes its dataset into a vtkImageData.
 
@@ -611,19 +610,20 @@ def loadNxs(filenames, output_image, dataset_path, **kwargs):
         The VTK image object where the output will be stored.
     dataset_path : str
         The internal HDF5 path to the dataset inside the .nxs file.
+    resample : bool, default=False
+        Whether to resample the dataset.
+    crop_image : bool, default=False
+        Whether to crop the dataset.
     **kwargs : dict
         - image_info (dict, optional): A dictionary to store metadata about the image.
         - progress_callback (callable, optional): Function to emit progress updates.
-        - resample (bool, default=False): Whether to resample the dataset.
-        - crop_image (bool, default=False): Whether to crop the dataset.
         - target_size (float, default=0.125): Target size for resampling (in GB).
         - origin (tuple, default=(0, 0, 0)): The origin coordinates for cropping.
         - target_z_extent (tuple, default=(0, 0)): The Z extent for cropping.
     """
     image_info = kwargs.get('image_info', None)
     progress_callback = kwargs.get('progress_callback')
-    resample = kwargs.get('resample', False)
-    crop_image = kwargs.get('crop_image', False)
+
     target_size = kwargs.get('target_size', 0.125)
     origin = kwargs.get('origin', (0, 0, 0))
     target_z_extent = kwargs.get('target_z_extent', (0, 0))

--- a/src/idvc/io.py
+++ b/src/idvc/io.py
@@ -303,9 +303,9 @@ class ImageDataCreator(object):
             elif data.dtype in ["int16", "uint16", "int32", "uint32", "float32", "float64"]:
                 vol_bit_depth = 16
             
-            if (numpy.issubdtype(data.dtype , numpy.signedinteger) or numpy.issubdtype(data.dtype , numpy.floating)) and numpy.any(data < 0):
+            if numpy.issubdtype(data.dtype , numpy.signedinteger) or numpy.issubdtype(data.dtype , numpy.floating):
                 warnings.warn(
-                f"Data of type {data.dtype} contains negative values. "
+                f"Data of type {data.dtype} may contain negative values. "
                 f"Negative values will be reinterpreted as positive values when cast to uint16.",
                 RuntimeWarning
                 )
@@ -732,14 +732,18 @@ def loadTif(*args, **kwargs):
 
         image_info['sampled'] = False
 
-    if image_data.dtype in ["int8", "uint8"]:
-        vol_bit_depth = 8
-    elif image_data.dtype in ["int16", "uint16", "int32", "uint32", "float32", "float64"]:
-        vol_bit_depth = 16
+    dtype = reader.GetOutputVTKType()
+    print(dtype)
 
-    if (numpy.issubdtype(image_data.dtype , numpy.signedinteger) or numpy.issubdtype(image_data.dtype , numpy.floating)) and numpy.any(image_data < 0):
+    if dtype in [vtk.VTK_CHAR, vtk.VTK_UNSIGNED_CHAR]:
+        vol_bit_depth = 8
+    elif dtype in [vtk.VTK_SHORT, vtk.VTK_UNSIGNED_SHORT, vtk.VTK_INT, vtk.VTK_UNSIGNED_INT,vtk.VTK_FLOAT, vtk.VTK_DOUBLE]:
+        vol_bit_depth = 16
+    print(vol_bit_depth)
+        
+    if dtype in [vtk.VTK_CHAR, vtk.VTK_SHORT, vtk.VTK_INT] or dtype in [vtk.VTK_FLOAT, vtk.VTK_DOUBLE]:
         warnings.warn(
-        f"Data of type {image_data.dtype} contains negative values. "
+        f"Data of type {dtype} may contain negative values. "
         f"Negative values will be reinterpreted as positive values when cast to uint16.",
         RuntimeWarning
         )

--- a/src/idvc/io.py
+++ b/src/idvc/io.py
@@ -1221,7 +1221,7 @@ def save_tiff_stack_as_raw(filenames: list, output_fname: str, progress_callback
 def save_nxs_as_raw(nexus_file, dataset_path, raw_file):
     """
     Converts a NeXus (.nxs) file to a raw binary file using the dataset path stored in 'dataset_path'.
-    If the dataset is not uint8 or uint16, it will be scaled to uint16.
+    If the dataset is not uint8 or uint16, it will be scaled to uint16. Negative values are clipped to zero.
 
     Parameters:
     -----------
@@ -1236,7 +1236,7 @@ def save_nxs_as_raw(nexus_file, dataset_path, raw_file):
         data = f[dataset_path]
         original_dtype = data.dtype
 
-        if original_dtype in [numpy.uint8, numpy.uint16, numpy.int8, numpy.int16]:
+        if original_dtype in [numpy.uint8, numpy.uint16]:
             with open(os.path.abspath(raw_file), 'wb') as f:
                 for i in range(data.shape[0]):
                     slice_data = data[i:i+1] 
@@ -1244,6 +1244,9 @@ def save_nxs_as_raw(nexus_file, dataset_path, raw_file):
             return
         
         else:
+            if numpy.issubdtype(original_dtype, numpy.signedinteger) or numpy.issubdtype(original_dtype, numpy.floating):
+                print("Clipping data negative values to zero.")
+                data = numpy.clip(data, 0, None)
             for i in range(data.shape[0]):
                 slice_data = data[i:i+1]
                 if i == 0:


### PR DESCRIPTION
- Closes #192 
- Closes #376
- Closes #417 
- Closes #421 
- Closes #424
- [x] Registration: The zextend in the cilviewer cropped reader has a bug. fixed in #https://github.com/TomographicImaging/CILViewer/pull/462. this is now released in v25.0.0.
- [x] Needs https://github.com/TomographicImaging/CILViewer/pull/452/files, hence the viewer version needs updating in recipe and meta
- [x] Edit Changelog
- [x] Edit helptext
- [x] Edit/Adds docstrings
- [x] Added attributes to the class ImageDataCreator
- [x] Moved methods inside the class and simplified the arguments. Added some more methods to simplify code
- [x]  connect the value error in `save_nxs_as_raw`  to a dialog using `displayErrorDialogFromWorker`. this is because `setup = Worker(self.dvc_runner.set_up)` is not connected to the error dialog. See the IO worker for an example on how to do this.
Opened https://github.com/TomographicImaging/iDVC/issues/423.
Maybe this PR closes https://github.com/TomographicImaging/iDVC/issues/61

- [x] Opened issue https://github.com/TomographicImaging/iDVC/issues/415 to bring the loading methods inside the class
- [x] Improved the class  `ImageDataCreator` and added an init
- [x] Adds Nexus load method `loadNxs` to convert file into vtkimage, which uses the nexus dialog from the viewer, `cilHDF5ResampleReader`. The load method is added to the  `ImageDataCreator`  class and some edits have been made to the required arguments, and an" else value error has been added to `cropped` and `resample`.
- [x] Added `HDF5InputDialog_onOk_redefined` so during registration and execution of dvc, the imagaedatacreator does not open a new dialog when the data is loaded again from scratch.
- [x] when the session is saved, the raw files are deleted even if the app is not closed. this is not ideal. I opened an issue https://github.com/TomographicImaging/iDVC/issues/416 to resolve this at a later stage
- [x] opened issue to delete temp folders when the app quits: https://github.com/TomographicImaging/iDVC/issues/391
- [x] Removed "bits_per_byte". Edited the way "vol_bit_depth" is defined. Ask @paskino Edo for confirmation of this.
- [x] Added a method to convert nexus files into raw converter in the dvc_runner. 
- [x] In the `save_tiff_stack_as_raw`  we used to have dtype in [numpy.uint8, numpy.uint16, numpy.int8, numpy.int16] which did not cast to uint16. Hoever, Brian's dvc core does not accept int8 and int16, we checked this with him directly, it accepts only uint8 and uint16. 
    "Yes, the code currently works with unsigned 8 and 16 bit integers. That is generally what you encounter with volumetric imaging data. I don’t think I’ve ever run across signed integer voxel representations. ".  As a result of the above, added the casting form int8 and int16 as well in the "else" code. This was done for tiff as well as nexus.
- [x] the definition of `vol_bit_depth` not entirely correct for meta, numpy and raw. Discussion 02/07/2025: opened issue #418 as the casting of numpy and meta to uint16 has not been implemented at all. I was only able to add 1 specific warning to the loadNpy. however these methods need to be revisited in a separate PR.
- [x] https://github.com/TomographicImaging/iDVC/blob/d49b7389665ae84dd42d7e6c524709c1c27665be/src/idvc/dvc_runner.py#L279-L282
I checked that this is ok for nexus and tiff because we cast them.

- [x] the nexus converter to raw is a reader slice by slice and updates min, max for every slice.
- [x] the nexus reader slice by slice works as it should when converting into a raw format. The data is written slice by slice from nexus to raw, and this is in the same order as the reading of the raw file in the core code. 07/07/2025 paskino said that the order should be C contiguous, he is happy with the way the casting is written.



- [x] when the converting files dialogs are opened, if there is an error everything freezes. it would be better to have an error dialog popping. opened issue https://github.com/TomographicImaging/iDVC/issues/392

### Tests performed:
- [x] I checked that the raw conversion is not repeated in a bulk run. this vas true even before this PR. I tested this.
- [x] I checked that the raw conversion is not repeated if a new run is performed in the same session, both bulk and single.
- [x] Tested numpy data, everything works until the end.
- [x] Tested nexus up to the end
- [x] Test tiff single full res
- [x] Test tiff single low res
- [x] Test tiff multiple images low res
- [x] Test raw full resolution, up to the end. Save session, load session
- [x] Test raw low res up to the end. save session, load session
- [x] Check that it deletes the raw files when the sessions are saved.

