### PR TITLE
Update dvc_interface.py

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # ChangeLog
 
+## v25.0.0
+Enhancements:
+* updated default values in Run DVC tab
+
 ## v24.1.1
 Bug fixes:
 * Fix abscissa order in graphs #372

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## v25.0.0
 Enhancements:
-* updated default values in Run DVC tab
+* updated default values in Run DVC tab #402
 
 ## v24.1.1
 Bug fixes:

--- a/src/idvc/dvc_interface.py
+++ b/src/idvc/dvc_interface.py
@@ -4293,7 +4293,7 @@ Future code development will introduce methods for better management of large di
         rdvc_widgets['run_max_displacement_label'].setToolTip(displacement_text)
         formLayout.setWidget(widgetno, QFormLayout.LabelRole, rdvc_widgets['run_max_displacement_label'])
         rdvc_widgets['run_max_displacement_entry'] = QSpinBox(groupBox)
-        rdvc_widgets['run_max_displacement_entry'].setValue(15)
+        rdvc_widgets['run_max_displacement_entry'].setValue(5)
         rdvc_widgets['run_max_displacement_entry'].setToolTip(displacement_text)
         formLayout.setWidget(widgetno, QFormLayout.FieldRole, rdvc_widgets['run_max_displacement_entry'])
         widgetno += 1
@@ -4313,7 +4313,7 @@ Translation only suffices for a quick, preliminary investigation.\nAdding rotati
         rdvc_widgets['run_ndof_entry'].addItem('3')
         rdvc_widgets['run_ndof_entry'].addItem('6')
         rdvc_widgets['run_ndof_entry'].addItem('12')
-        rdvc_widgets['run_ndof_entry'].setCurrentIndex(1)
+        rdvc_widgets['run_ndof_entry'].setCurrentIndex(2)
         rdvc_widgets['run_ndof_entry'].setToolTip(dof_text)
         formLayout.setWidget(widgetno, QFormLayout.FieldRole, rdvc_widgets['run_ndof_entry'])
         widgetno += 1
@@ -4404,7 +4404,7 @@ This parameter has a strong effect on computation time, so be careful."
         rdvc_widgets['subvol_points_spinbox'] = QSpinBox(singleRun_groupBox)
         rdvc_widgets['subvol_points_spinbox'].setMinimum(100)
         rdvc_widgets['subvol_points_spinbox'].setMaximum(50000)
-        rdvc_widgets['subvol_points_spinbox'].setValue(10000)
+        rdvc_widgets['subvol_points_spinbox'].setValue(1000)
         rdvc_widgets['subvol_points_spinbox'].setToolTip(subvol_points_text)
 
         singleRun_groupBoxFormLayout.setWidget(widgetno, QFormLayout.FieldRole, rdvc_widgets['subvol_points_spinbox'])


### PR DESCRIPTION
- closes #401

Updates the following parameters:
- [x] [Maximum displacement](https://github.com/TomographicImaging/iDVC/blob/ae92a7d17791ba364846ff746178f5871cafd657/src/idvc/dvc_interface.py#L4296): set to 5
- [x] [Number of Optimisation Parameters](https://github.com/TomographicImaging/iDVC/blob/ae92a7d17791ba364846ff746178f5871cafd657/src/idvc/dvc_interface.py#L4316): set to 12
- [x] [Sampling points in subvolume](https://github.com/TomographicImaging/iDVC/blob/ae92a7d17791ba364846ff746178f5871cafd657/src/idvc/dvc_interface.py#L4407): set to 1000