### PR TITLE
Macos build with Qt5

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,21 @@ iDVC depends on code initially developed by Prof. Brian K. Bay and collaborators
 [1] B. K. Bay, T. S. Smith, D. P. Fyhrie, M. Saad "Digital volume correlation: Three-dimensional strain mapping using x-ray tomography", *Experimental Mechanics* **39** 217–226, 1999. [DOI: 10.1007/BF02323555](https://doi.org/10.1007/BF02323555)
 
 [2] B. K. Bay "Methods and applications of digital volume correlation", *J. Strain Analysis* **43** 745-760, 2008. [DOI: 10.1243/03093247JSA436](https://doi.org/10.1243/03093247JSA436)
+
+
+# MacOS + Qt + VTK
+
+`conda-forge`'s VTK package depends on Qt6 and we only tested this app with Qt5. On MacOS this seems to be a problem as the OS finds 2 files which provide the same functionality so it raises an error and nothing works. The suggested workaround is to install the CILViewer (from the repo), `PySide2` (`conda-forge`) and [VTK](https://docs.vtk.org/en/latest/advanced/available_python_wheels.html) (from Kitware's wheels) manually.
+
+
+```bash
+pip install --extra-index-url https://wheels.vtk.org vtk
+```
+
+```yaml
+dependencies:
+  - pip
+  - pip:
+    - --extra-index-url https://wheels.vtk.org
+    - vtk
+```

--- a/scripts/texture-oxtail.py
+++ b/scripts/texture-oxtail.py
@@ -1,0 +1,122 @@
+#%%
+from tracemalloc import start
+
+import numpy as np
+from skimage.feature import graycomatrix, graycoprops
+import matplotlib.pyplot as plt
+import vtk
+from ccpi.viewer.utils.conversion import cilRawCroppedReader
+
+#%%
+# data = np.load("/Users/edoardo.pasca/Data/DVC_test_images/frame_000_f.npy")
+# /Users/edoardo.pasca/Data/ALC-421/CC/123744_854xy_720z_8bitEP.raw
+data_file = "/Users/edoardo.pasca/Data/ALC-421/CC/123744_854xy_720z_8bitEP.raw"
+reader = cilRawCroppedReader()
+reader.SetFileName(data_file)
+reader.SetStoredArrayShape((720, 854, 854))
+reader.SetTargetZExtent((270, 270))
+reader.SetOutputVTKType(vtk.VTK_UNSIGNED_CHAR)
+reader.Update()
+vtkdata = reader.GetOutput()
+
+#%%
+# from ccpi.viewer import CILViewer2D as viewer
+# v = viewer.CILViewer2D()
+# v.setInputData(vtkdata)
+# v.startRenderLoop()
+# exit()
+#%%
+from ccpi.viewer.utils.conversion import Converter
+data = Converter.vtk2numpy(vtkdata)[0]
+
+#%%
+fig, ax = plt.subplots()
+ax.imshow(data, cmap='gray')
+
+start = 700
+dsize = 20
+ax.plot([start + i for i in range(dsize)], [750 for i in range(dsize)], color='C1', linewidth=2)
+plt.show()
+
+# %%
+# get a subsection of the image
+registration_region = 250
+registration_p0 = [500,500]
+
+sub_image = data[
+                 registration_p0[0]:registration_p0[0]+registration_region,
+                 registration_p0[1]:registration_p0[1]+registration_region]
+
+fig, ax = plt.subplots()
+
+ax.imshow(sub_image, cmap='gray')
+start = 100
+xlength = 150
+ax.plot([start + i for i in range(dsize)], [xlength for i in range(dsize)], color='C1', linewidth=2)
+plt.show()
+#%%
+
+# Visualise the sub-image within the whole image
+# and the size of the features we are tracking on
+from matplotlib.patches import Rectangle
+box = Rectangle((registration_p0[1], registration_p0[0]), registration_region, registration_region, linewidth=2, edgecolor='white', facecolor='none')
+
+fig, ax = plt.subplots()
+ax.imshow(data, cmap='gray')
+start = 600
+ax.plot([start + i for i in range(dsize)], [registration_p0[1] + registration_region//2 for i in range(dsize)], color='C1', linewidth=2)
+ax.add_patch(box)
+sax = ax.inset_axes([0, 0.5, 0.5, 0.5])
+sax.imshow(sub_image, cmap='gray')
+sax.get_xaxis().set_visible(False)
+sax.get_yaxis().set_visible(False)
+start = start - registration_p0[0]
+sax.plot([start + i for i in range(dsize)], [registration_region//2 for i in range(dsize)], color='C1', linewidth=2)
+plt.show()
+
+# %%
+distances = [i for i in range(80)]
+angles = [0, np.pi/2, np.pi/4, 3*np.pi/4]
+
+result = graycomatrix(sub_image, distances=distances, angles=angles, levels=256, 
+                      symmetric=False, normed=False)
+
+# %%
+contrast = graycoprops(result, 'contrast')
+dissimilarity = graycoprops(result, 'dissimilarity')
+homogeneity = graycoprops(result, 'homogeneity')
+ASM = graycoprops(result, 'ASM')
+energy = graycoprops(result, 'energy')
+#%%
+plt.style.use('tableau-colorblind10')
+
+plt.plot(homogeneity.T[0], label='Homogeneity')
+plt.plot(ASM.T[0], label='ASM')
+plt.plot(energy.T[0], label='Energy')
+plt.legend()
+# %%
+# plt.plot(dissimilarity.T[0], label='Dissimilarity')
+for a in angles:
+    plt.plot(contrast.T[angles.index(a)], label=f'angle {np.degrees(a)}')
+plt.title('Contrast')
+plt.xlabel('Distance')
+plt.legend()
+# plt.legend()
+# %%
+for a in angles:
+    plt.plot(dissimilarity.T[angles.index(a)], label=f'angle {np.degrees(a)}')
+plt.title('Dissimilarity')
+plt.xlabel('Distance')
+plt.legend()
+# %%
+fig, ax = plt.subplots(2, 1, figsize=(10, 10))
+
+for a in angles:
+    ax[0].plot(contrast.T[angles.index(a)], label=f'angle {np.degrees(a)}')
+    ax[1].plot(dissimilarity.T[angles.index(a)], label=f'angle {np.degrees(a)}')
+ax[0].set_title('Contrast')
+ax[1].set_title('Dissimilarity')
+ax[1].set_xlabel('Distance')
+ax[0].legend()
+ax[1].legend()
+# %%

--- a/scripts/texture-oxtail.py
+++ b/scripts/texture-oxtail.py
@@ -6,6 +6,9 @@ from skimage.feature import graycomatrix, graycoprops
 import matplotlib.pyplot as plt
 import vtk
 from ccpi.viewer.utils.conversion import cilRawCroppedReader
+import os
+
+output_dir = os.path.abspath( "/Users/edoardo.pasca/Analysis/ALC-421/plots" )
 
 #%%
 # data = np.load("/Users/edoardo.pasca/Data/DVC_test_images/frame_000_f.npy")
@@ -64,19 +67,19 @@ box = Rectangle((registration_p0[1], registration_p0[0]), registration_region, r
 fig, ax = plt.subplots()
 ax.imshow(data, cmap='gray')
 start = 600
-ax.plot([start + i for i in range(dsize)], [registration_p0[1] + registration_region//2 for i in range(dsize)], color='C1', linewidth=2)
+ax.plot([start + i for i in range(dsize)], [registration_p0[0] + registration_region//2 for i in range(dsize)], color='C1', linewidth=2)
 ax.add_patch(box)
 sax = ax.inset_axes([0, 0.5, 0.5, 0.5])
 sax.imshow(sub_image, cmap='gray')
 sax.get_xaxis().set_visible(False)
 sax.get_yaxis().set_visible(False)
-start = start - registration_p0[0]
+start = start - registration_p0[1]
 sax.plot([start + i for i in range(dsize)], [registration_region//2 for i in range(dsize)], color='C1', linewidth=2)
 plt.show()
 
 # %%
-distances = [i for i in range(80)]
-angles = [0, np.pi/2, np.pi/4, 3*np.pi/4]
+distances = np.asarray([i for i in range(40)])
+angles = [ i * np.pi/4 for i in range(4)]
 
 result = graycomatrix(sub_image, distances=distances, angles=angles, levels=256, 
                       symmetric=False, normed=False)
@@ -96,27 +99,42 @@ plt.plot(energy.T[0], label='Energy')
 plt.legend()
 # %%
 # plt.plot(dissimilarity.T[0], label='Dissimilarity')
+
+# yy = np.gradient(contrast.T[0], distances/2)
+# threshold = yy < (yy.max() * 0.1)
+# for i in range(len(yy)):
+#     if threshold[i]:
+#         break
+# print (i, distances[i]*2)
+
 for a in angles:
-    plt.plot(contrast.T[angles.index(a)], label=f'angle {np.degrees(a)}')
+    plt.plot(distances*2,contrast.T[angles.index(a)], label=f'angle {np.degrees(a)}')
+    # plt.plot(distances*2,
+    #          yy,
+    #          label=f'angle {np.degrees(a)}')
 plt.title('Contrast')
-plt.xlabel('Distance')
+plt.xlabel('Subvolume size')
 plt.legend()
 # plt.legend()
 # %%
 for a in angles:
-    plt.plot(dissimilarity.T[angles.index(a)], label=f'angle {np.degrees(a)}')
+    plt.plot(distances*2,dissimilarity.T[angles.index(a)], label=f'angle {np.degrees(a)}')
 plt.title('Dissimilarity')
-plt.xlabel('Distance')
+plt.xlabel('Subvolume size')
 plt.legend()
 # %%
 fig, ax = plt.subplots(2, 1, figsize=(10, 10))
-
+x = distances*2
 for a in angles:
-    ax[0].plot(contrast.T[angles.index(a)], label=f'angle {np.degrees(a)}')
-    ax[1].plot(dissimilarity.T[angles.index(a)], label=f'angle {np.degrees(a)}')
+    ax[0].plot(x, contrast.T[angles.index(a)], label=f'angle {np.degrees(a)}')
+    ax[1].plot(x, dissimilarity.T[angles.index(a)], label=f'angle {np.degrees(a)}')
 ax[0].set_title('Contrast')
 ax[1].set_title('Dissimilarity')
-ax[1].set_xlabel('Distance')
+ax[1].set_xlabel('Subvolume size')
 ax[0].legend()
 ax[1].legend()
+# %%
+fig.savefig(os.path.join(output_dir, "oxtail-texture_analysis.png"), 
+            dpi=300,
+            bbox_inches="tight")
 # %%

--- a/scripts/texture.py
+++ b/scripts/texture.py
@@ -1,0 +1,95 @@
+#%%
+from tracemalloc import start
+
+import numpy as np
+from skimage.feature import graycomatrix, graycoprops
+import matplotlib.pyplot as plt
+
+#%%
+data = np.load("/Users/edoardo.pasca/Data/DVC_test_images/frame_000_f.npy")
+
+fig, ax = plt.subplots()
+ax.imshow(data[500], cmap='gray')
+
+start = 700
+ax.plot([start + i for i in range(40)], [750 for i in range(40)], color='C1', linewidth=2)
+plt.show()
+
+# %%
+# get a subsection of the image
+registration_region = 250
+registration_p0 = [600,600]
+
+sub_image = data[500,
+                 registration_p0[0]:registration_p0[0]+registration_region,
+                 registration_p0[1]:registration_p0[1]+registration_region]
+
+fig, ax = plt.subplots()
+
+ax.imshow(sub_image, cmap='gray')
+start = 100
+ax.plot([start + i for i in range(40)], [150 for i in range(40)], color='C1', linewidth=2)
+plt.show()
+#%%
+
+# Visualise the sub-image within the whole image
+# and the size of the features we are tracking on
+
+fig, ax = plt.subplots()
+ax.imshow(data[500], cmap='gray')
+start = 700
+ax.plot([start + i for i in range(40)], [750 for i in range(40)], color='C1', linewidth=2)
+sax = ax.inset_axes([0, 0.5, 0.5, 0.5])
+sax.imshow(sub_image, cmap='gray')
+sax.get_xaxis().set_visible(False)
+sax.get_yaxis().set_visible(False)
+start = start - registration_p0[0]
+sax.plot([start + i for i in range(40)], [150 for i in range(40)], color='C1', linewidth=2)
+plt.show()
+
+# %%
+distances = [i for i in range(80)]
+angles = [0, np.pi/4, np.pi/2, 3*np.pi/4]
+
+result = graycomatrix(sub_image, distances=distances, angles=angles, levels=256, 
+                      symmetric=False, normed=False)
+
+# %%
+contrast = graycoprops(result, 'contrast')
+dissimilarity = graycoprops(result, 'dissimilarity')
+homogeneity = graycoprops(result, 'homogeneity')
+ASM = graycoprops(result, 'ASM')
+energy = graycoprops(result, 'energy')
+#%%
+plt.style.use('tableau-colorblind10')
+
+plt.plot(homogeneity.T[0], label='Homogeneity')
+plt.plot(ASM.T[0], label='ASM')
+plt.plot(energy.T[0], label='Energy')
+plt.legend()
+# %%
+# plt.plot(dissimilarity.T[0], label='Dissimilarity')
+for a in angles:
+    plt.plot(contrast.T[angles.index(a)], label=f'angle {np.degrees(a)}')
+plt.title('Contrast')
+plt.xlabel('Distance')
+plt.legend()
+# plt.legend()
+# %%
+for a in angles:
+    plt.plot(dissimilarity.T[angles.index(a)], label=f'angle {np.degrees(a)}')
+plt.title('Dissimilarity')
+plt.xlabel('Distance')
+plt.legend()
+# %%
+fig, ax = plt.subplots(2, 1, figsize=(10, 10))
+
+for a in angles:
+    ax[0].plot(contrast.T[angles.index(a)], label=f'angle {np.degrees(a)}')
+    ax[1].plot(dissimilarity.T[angles.index(a)], label=f'angle {np.degrees(a)}')
+ax[0].set_title('Contrast')
+ax[1].set_title('Dissimilarity')
+ax[1].set_xlabel('Distance')
+ax[0].legend()
+ax[1].legend()
+# %%

--- a/scripts/texture.py
+++ b/scripts/texture.py
@@ -4,6 +4,9 @@ from tracemalloc import start
 import numpy as np
 from skimage.feature import graycomatrix, graycoprops
 import matplotlib.pyplot as plt
+import os
+
+output_dir = os.path.abspath( "/Users/edoardo.pasca/Analysis/ALC-421/plots" )
 
 #%%
 data = np.load("/Users/edoardo.pasca/Data/DVC_test_images/frame_000_f.npy")
@@ -12,13 +15,14 @@ fig, ax = plt.subplots()
 ax.imshow(data[500], cmap='gray')
 
 start = 700
-ax.plot([start + i for i in range(40)], [750 for i in range(40)], color='C1', linewidth=2)
+dsize = 40
+ax.plot([start + i for i in range(dsize)], [750 for i in range(dsize)], color='C1', linewidth=2)
 plt.show()
 
 # %%
 # get a subsection of the image
 registration_region = 250
-registration_p0 = [600,600]
+registration_p0 = [650,600]
 
 sub_image = data[500,
                  registration_p0[0]:registration_p0[0]+registration_region,
@@ -28,28 +32,32 @@ fig, ax = plt.subplots()
 
 ax.imshow(sub_image, cmap='gray')
 start = 100
-ax.plot([start + i for i in range(40)], [150 for i in range(40)], color='C1', linewidth=2)
+ax.plot([start + i for i in range(dsize)], [150 for i in range(dsize)], color='C1', linewidth=2)
 plt.show()
 #%%
 
 # Visualise the sub-image within the whole image
 # and the size of the features we are tracking on
+from matplotlib.patches import Rectangle
+box = Rectangle((registration_p0[1], registration_p0[0]), registration_region, registration_region, linewidth=2, edgecolor='white', facecolor='none')
 
 fig, ax = plt.subplots()
 ax.imshow(data[500], cmap='gray')
 start = 700
-ax.plot([start + i for i in range(40)], [750 for i in range(40)], color='C1', linewidth=2)
+ax.plot([start + i for i in range(dsize)], [registration_p0[0] + registration_region//2  for i in range(dsize)], color='C1', linewidth=2)
+ax.add_patch(box)
 sax = ax.inset_axes([0, 0.5, 0.5, 0.5])
 sax.imshow(sub_image, cmap='gray')
 sax.get_xaxis().set_visible(False)
 sax.get_yaxis().set_visible(False)
-start = start - registration_p0[0]
-sax.plot([start + i for i in range(40)], [150 for i in range(40)], color='C1', linewidth=2)
+start = start - registration_p0[1]
+sax.plot([start + i for i in range(dsize)], [registration_region//2 for i in range(dsize)], color='C1', linewidth=2)
 plt.show()
 
 # %%
-distances = [i for i in range(80)]
-angles = [0, np.pi/4, np.pi/2, 3*np.pi/4]
+distances = np.asarray([i for i in range(40)])
+angles = [ i * np.pi/4 for i in range(4)]
+x = distances*2
 
 result = graycomatrix(sub_image, distances=distances, angles=angles, levels=256, 
                       symmetric=False, normed=False)
@@ -70,26 +78,30 @@ plt.legend()
 # %%
 # plt.plot(dissimilarity.T[0], label='Dissimilarity')
 for a in angles:
-    plt.plot(contrast.T[angles.index(a)], label=f'angle {np.degrees(a)}')
+    plt.plot(x, contrast.T[angles.index(a)], label=f'angle {np.degrees(a)}')
 plt.title('Contrast')
-plt.xlabel('Distance')
+plt.xlabel('Subvolume size')
 plt.legend()
 # plt.legend()
 # %%
 for a in angles:
-    plt.plot(dissimilarity.T[angles.index(a)], label=f'angle {np.degrees(a)}')
+    plt.plot(x, dissimilarity.T[angles.index(a)], label=f'angle {np.degrees(a)}')
 plt.title('Dissimilarity')
-plt.xlabel('Distance')
+plt.xlabel('Subvolume size')
 plt.legend()
 # %%
 fig, ax = plt.subplots(2, 1, figsize=(10, 10))
 
 for a in angles:
-    ax[0].plot(contrast.T[angles.index(a)], label=f'angle {np.degrees(a)}')
-    ax[1].plot(dissimilarity.T[angles.index(a)], label=f'angle {np.degrees(a)}')
+    ax[0].plot(x, contrast.T[angles.index(a)], label=f'angle {np.degrees(a)}')
+    ax[1].plot(x, dissimilarity.T[angles.index(a)], label=f'angle {np.degrees(a)}')
 ax[0].set_title('Contrast')
 ax[1].set_title('Dissimilarity')
-ax[1].set_xlabel('Distance')
+ax[1].set_xlabel('Subvolume size')
 ax[0].legend()
 ax[1].legend()
+# %%
+fig.savefig(os.path.join(output_dir, "lava-texture_analysis.png"), 
+            dpi=300,
+            bbox_inches="tight")
 # %%

--- a/src/idvc/dvc_interface.py
+++ b/src/idvc/dvc_interface.py
@@ -1804,16 +1804,26 @@ It is used as a global starting point and a translation reference."
             if not (hasattr(self, 'unsampled_ref_image_data') and hasattr(self, 'unsampled_corr_image_data')):
                 #print("About to create image")
                 self.unsampled_ref_image_data = vtk.vtkImageData()
-                image_data_creator = ImageDataCreator(self, self.image[0], self.unsampled_ref_image_data, info_var=self.unsampled_image_info, crop_image=True, origin=origin,
-                                                 target_z_extent=target_z_extent)
-                image_data_creator.createImageData(output_dir=os.path.abspath(tempfile.tempdir), finish_fn=self.LoadCorrImageForReg, crop_corr_image=True)
+                image_data_creator = ImageDataCreator(self, 
+                                                      self.image[0], 
+                                                      self.unsampled_ref_image_data, 
+                                                      info_var=self.unsampled_image_info, crop_image=True, 
+                                                      origin=origin,
+                                                      target_z_extent=target_z_extent)
+                image_data_creator.createImageData(output_dir=os.path.abspath(tempfile.tempdir),
+                                                   finish_fn=self.LoadCorrImageForReg, crop_corr_image=True)
                 #TODO: move to doing both image data creators simultaneously - would this work?
                 return
 
             if previous_reg_box_extent != reg_box_extent: # If registration box is changed need to update the cropped images.
-                image_data_creator = ImageDataCreator(self, self.image[0], self.unsampled_ref_image_data, info_var=self.unsampled_image_info, crop_image=True, origin=origin,
-                                                 target_z_extent=target_z_extent)
-                image_data_creator.createImageData(output_dir=os.path.abspath(tempfile.tempdir), finish_fn=self.LoadCorrImageForReg, crop_corr_image=True)
+                image_data_creator = ImageDataCreator(self, 
+                                                      self.image[0], 
+                                                      self.unsampled_ref_image_data, 
+                                                      info_var=self.unsampled_image_info, crop_image=True, 
+                                                      origin=origin,
+                                                      target_z_extent=target_z_extent)
+                image_data_creator.createImageData(output_dir=os.path.abspath(tempfile.tempdir),
+                                                   finish_fn=self.LoadCorrImageForReg, crop_corr_image=True)
             else:
                 self.completeRegistration()
             
@@ -1828,6 +1838,7 @@ It is used as a global starting point and a translation reference."
                 else:
                     self.completeRegistration()
 
+    
     def enlarge_extent(self, dim):
         """
         Given the regitration box size inputted by the user and the coordinates of the point zero wrt the unsampled volumes, 
@@ -1858,8 +1869,14 @@ It is used as a global starting point and a translation reference."
         z_extent = self.target_cropped_image_z_extent
 
         self.unsampled_corr_image_data = vtk.vtkImageData()
-        image_data_creator = ImageDataCreator(self, self.image[1], self.unsampled_corr_image_data, info_var=self.unsampled_image_info, resample=resample_corr_image, crop_image=crop_corr_image, origin=origin, target_z_extent=z_extent)
-        image_data_creator.createImageData(finish_fn=self.completeRegistration, output_dir=os.path.abspath(tempfile.tempdir))
+        image_data_creator = ImageDataCreator(self, 
+                                              self.image[1], 
+                                              self.unsampled_corr_image_data, 
+                                              info_var=self.unsampled_image_info, resample=resample_corr_image, crop_image=crop_corr_image, 
+                                              origin=origin, 
+                                              target_z_extent=z_extent)
+        image_data_creator.createImageData(finish_fn=self.completeRegistration, 
+                                           output_dir=os.path.abspath(tempfile.tempdir))
 
     def completeRegistration(self):
         """It shows the registration difference volume in the viewer and sets up the tab for the registration. 
@@ -3131,11 +3148,39 @@ File format allowed: 'roi', 'txt', 'csv, 'xlxs', 'inp'.")
     @pysnooper.snoop()
     def displaySubvolumeTexture(self):
         window = FormDialog(None, "Test FormDialog")
-        p0 = self.registration_parameters['point_zero_entry'].text()
+        # read as list
+        p0 = eval(str(self.registration_parameters['point_zero_entry'].text()))
         regbox = self.registration_parameters['registration_box_size_entry'].value()
 
         window.addWidget(QLabel(f"Point 0: {p0}"), qlabel="P0", name='P0',)
         window.addWidget(QLabel(f"Registration box size: {regbox}"), qlabel="RegBox", name='RegBox',)
+
+        origin = self.target_cropped_image_origin 
+        z_extent = self.target_cropped_image_z_extent
+        vtkdata3d = self.unsampled_corr_image_data
+        extent = vtkdata3d.GetExtent()
+
+        extent = self.getRegistrationBoxExtentInWorldCoords()
+
+        # get the selected ROI
+        voi = vtk.vtkExtractVOI()
+        
+        voi.SetInputData(self.unsampled_ref_image_data) 
+
+        voi.SetVOI(*extent)
+        voi.Update()
+        # vtkdata3d.SetOrigin((0,0,z_extent[0]))
+
+        from ccpi.viewer.QCILViewerWidget import QCILViewerWidget
+        from ccpi.viewer import viewer2D
+        frame = QCILViewerWidget(window, 
+                                 viewer=viewer2D, shape=(200, 200),
+                                 debug=False)
+        vtkdata3d = voi.GetOutput()
+        frame.viewer.setInputData(vtkdata3d)
+        
+        data3d = Converter.vtk2numpy(vtkdata3d)
+
         
         # data3d = load_data3d(stored_size, roi3d)
         # print (f"Data shape: {data.shape}, Data3D shape: {data3d.shape}")
@@ -3162,15 +3207,17 @@ File format allowed: 'roi', 'txt', 'csv, 'xlxs', 'inp'.")
         # ax[1,0].imshow(np.squeeze(data3d[:, 0, roi3d[0]:roi3d[1]]), cmap='gray')
         # ax[1,1].imshow(np.squeeze(data3d[:, roi3d[2]:roi3d[3], 0]), cmap='gray')
         # Create canvas and optional toolbar for interactive navigation
-        fig, ax = plt.subplots(1, 1, figsize=(10, 10))
-        ax.plot(distances, label='Distances')
-        ax.legend()
+        fig, ax = plt.subplots(1, 1, figsize=(5, 5))
+        # ax[0].plot(distances, label='Distances')
+        # ax[0].legend()
+        ax.imshow(data3d[regbox//2,:,:], cmap='gray')
         canvas = FigureCanvas(fig)
         toolbar = NavigationToolbar(canvas, window)
     
         # Put toolbar + canvas into a vertical layout and set it on the dialog
         window.addSpanningWidget(toolbar, name='toolbar')
         window.addSpanningWidget(canvas, name='canvas')
+        window.addSpanningWidget(frame, name='viewer')
         
         window.exec_()
 

--- a/src/idvc/dvc_interface.py
+++ b/src/idvc/dvc_interface.py
@@ -2811,6 +2811,7 @@ It is used as a global starting point and a translation reference."
         self.subvolumeShapeValue.addItem("Sphere")
         self.subvolumeShapeValue.setCurrentIndex(0)
         self.subvolumeShapeValue.currentTextChanged.connect(self.displaySubvolumePreview)
+        pc['pointcloud_volume_shape_entry'] = self.subvolumeShapeValue
 
         self.graphWidgetFL.setWidget(widgetno, QFormLayout.FieldRole, self.subvolumeShapeValue)
         widgetno += 1
@@ -2820,6 +2821,7 @@ It is used as a global starting point and a translation reference."
         self.subvolumeTextureLabel.setText("Volume texture measurement")
         self.graphWidgetFL.setWidget(widgetno, QFormLayout.LabelRole, self.subvolumeTextureLabel)
         self.subvolumeTextureValue = QPushButton(self.graphParamsGroupBox)
+        self.subvolumeTextureValue.setText("Show")
         self.subvolumeTextureValue.clicked.connect(self.displaySubvolumeTexture)
 
         self.graphWidgetFL.setWidget(widgetno, QFormLayout.FieldRole, self.subvolumeTextureValue)
@@ -3125,13 +3127,15 @@ File format allowed: 'roi', 'txt', 'csv, 'xlxs', 'inp'.")
         self.pointcloud_is = 'generated'
         self.createSavePointCloudWindow(save_only=False)
 
+    import pysnooper
+    @pysnooper.snoop()
     def displaySubvolumeTexture(self):
         window = FormDialog(None, "Test FormDialog")
-        p0 = self.registration_parameters['point_zero_location'].value()
+        p0 = self.registration_parameters['point_zero_entry'].text()
         regbox = self.registration_parameters['registration_box_size_entry'].value()
 
-        window.addWidget('P0', QLabel(f"Point 0: {p0}"))
-        window.addWidget('RegBox', QLabel(f"Registration box size: {regbox}"))
+        window.addWidget(QLabel(f"Point 0: {p0}"), qlabel="P0", name='P0',)
+        window.addWidget(QLabel(f"Registration box size: {regbox}"), qlabel="RegBox", name='RegBox',)
         
         # data3d = load_data3d(stored_size, roi3d)
         # print (f"Data shape: {data.shape}, Data3D shape: {data3d.shape}")
@@ -3168,7 +3172,7 @@ File format allowed: 'roi', 'txt', 'csv, 'xlxs', 'inp'.")
         window.addSpanningWidget(toolbar, name='toolbar')
         window.addSpanningWidget(canvas, name='canvas')
         
-        window.show()
+        window.exec_()
 
     def displaySubvolumePreview(self):
         if self.pointcloud_parameters['subvolume_preview_check'].isChecked():

--- a/src/idvc/dvc_interface.py
+++ b/src/idvc/dvc_interface.py
@@ -2814,7 +2814,17 @@ It is used as a global starting point and a translation reference."
 
         self.graphWidgetFL.setWidget(widgetno, QFormLayout.FieldRole, self.subvolumeShapeValue)
         widgetno += 1
-        pc['pointcloud_volume_shape_entry'] = self.subvolumeShapeValue
+
+        # Add show texture measurement
+        self.subvolumeTextureLabel = QLabel(self.graphParamsGroupBox)
+        self.subvolumeTextureLabel.setText("Volume texture measurement")
+        self.graphWidgetFL.setWidget(widgetno, QFormLayout.LabelRole, self.subvolumeTextureLabel)
+        self.subvolumeTextureValue = QPushButton(self.graphParamsGroupBox)
+        self.subvolumeTextureValue.clicked.connect(self.displaySubvolumeTexture)
+
+        self.graphWidgetFL.setWidget(widgetno, QFormLayout.FieldRole, self.subvolumeTextureValue)
+        widgetno += 1
+        pc['pointcloud_volume_texture_entry'] = self.subvolumeTextureValue
 
         # Add horizonal seperator
         # Generate panel
@@ -3114,6 +3124,51 @@ File format allowed: 'roi', 'txt', 'csv, 'xlxs', 'inp'.")
     def _generatePointCloudClicked(self):
         self.pointcloud_is = 'generated'
         self.createSavePointCloudWindow(save_only=False)
+
+    def displaySubvolumeTexture(self):
+        window = FormDialog(None, "Test FormDialog")
+        p0 = self.registration_parameters['point_zero_location'].value()
+        regbox = self.registration_parameters['registration_box_size_entry'].value()
+
+        window.addWidget('P0', QLabel(f"Point 0: {p0}"))
+        window.addWidget('RegBox', QLabel(f"Registration box size: {regbox}"))
+        
+        # data3d = load_data3d(stored_size, roi3d)
+        # print (f"Data shape: {data.shape}, Data3D shape: {data3d.shape}")
+    
+        # exit()
+        max_size = 40
+        
+        distances = np.asarray([i for i in range(max_size)])
+        angles = [ i * np.pi/4 for i in range(4)]
+    
+        # XY plane
+    
+        # fig, ax = plt.subplots(3, 1, figsize=(10, 10))
+        # ax[2].imshow(data, cmap='gray')
+        # create_plots(data, distances, angles, fig, ax)
+    
+        # fig, ax = plt.subplots(2, 2, figsize=(10, 10))
+        # ax[0,0].imshow(data[roi3d[2]:roi3d[3], roi3d[0]:roi3d[1]], cmap='gray')
+        
+        # ax[0,1].imshow(data3d[0, roi3d[2]:roi3d[3], roi3d[0]:roi3d[1]], cmap='gray')
+    
+        # # Z has been already cropped on read
+        # print("Shape y cut", data3d[:, 0, roi3d[0]:roi3d[1]].shape)
+        # ax[1,0].imshow(np.squeeze(data3d[:, 0, roi3d[0]:roi3d[1]]), cmap='gray')
+        # ax[1,1].imshow(np.squeeze(data3d[:, roi3d[2]:roi3d[3], 0]), cmap='gray')
+        # Create canvas and optional toolbar for interactive navigation
+        fig, ax = plt.subplots(1, 1, figsize=(10, 10))
+        ax.plot(distances, label='Distances')
+        ax.legend()
+        canvas = FigureCanvas(fig)
+        toolbar = NavigationToolbar(canvas, window)
+    
+        # Put toolbar + canvas into a vertical layout and set it on the dialog
+        window.addSpanningWidget(toolbar, name='toolbar')
+        window.addSpanningWidget(canvas, name='canvas')
+        
+        window.show()
 
     def displaySubvolumePreview(self):
         if self.pointcloud_parameters['subvolume_preview_check'].isChecked():


### PR DESCRIPTION
On Macos the presence of both Qt5 and Qt6 in the environment lead to an error:

```
objc[72053]: Class QT_ROOT_LEVEL_POOL__THESE_OBJECTS_WILL_BE_RELEASED_WHEN_QAPP_GOES_OUT_OF_SCOPE is implemented in both /Users/Brian/miniconda3/envs/idvc_environment/lib/libQt6Core.6.11.2.dylib (0x133315728) and /Users/Brian/miniconda3/envs/idvc_environment/lib/libQt5Core.5.15.15.dylib (0x161fd12f8). One of the two will be used. Which one is undefined.

objc[72053]: Class KeyValueObserver is implemented in both /Users/Brian/miniconda3/envs/idvc_environment/lib/libQt6Core.6.11.2.dylib (0x133315750) and /Users/Brian/miniconda3/envs/idvc_environment/lib/libQt5Core.5.15.15.dylib (0x161fd1320). One of the two will be used. Which one is undefined.

objc[72053]: Class RunLoopModeTracker is implemented in both /Users/Brian/miniconda3/envs/idvc_environment/lib/libQt6Core.6.11.2.dylib (0x1333157a0) and /Users/Brian/miniconda3/envs/idvc_environment/lib/libQt5Core.5.15.15.dylib (0x161fd1370). One of the two will be used. Which one is undefined.

Segmentation fault: 11
```

This PR removes the issue by forcing Qt5.